### PR TITLE
SOF-1523 No longer does a Take on activation of Rundown

### DIFF
--- a/src/business-logic/services/rundown-event-builder-implementation.ts
+++ b/src/business-logic/services/rundown-event-builder-implementation.ts
@@ -29,9 +29,7 @@ export class RundownEventBuilderImplementation implements RundownEventBuilder {
     return {
       type: RundownEventType.ACTIVATED,
       timestamp: Date.now(),
-      rundownId: rundown.id,
-      segmentId: rundown.getActiveSegment().id,
-      partId: rundown.getActivePart().id,
+      rundownId: rundown.id
     }
   }
 

--- a/src/business-logic/services/rundown-timeline-service.ts
+++ b/src/business-logic/services/rundown-timeline-service.ts
@@ -50,7 +50,20 @@ export class RundownTimelineService implements RundownService {
     await this.rundownRepository.saveRundown(rundown)
   }
 
-  private async buildAndPersistTimeline(rundown: Rundown): Promise<Timeline> {
+  private buildAndPersistTimeline(rundown: Rundown): Promise<Timeline> {
+    return rundown.isActivePartSet()
+      ? this.buildAndPersistTimelineWithBlueprint(rundown)
+      : this.buildAndPersistTimelineWithoutBlueprint(rundown)
+  }
+
+  private async buildAndPersistTimelineWithoutBlueprint(rundown: Rundown): Promise<Timeline> {
+    const configuration: Configuration = await this.configurationRepository.getConfiguration()
+    const timeline: Timeline = this.timelineBuilder.buildTimeline(rundown, configuration.studio)
+    this.timelineRepository.saveTimeline(timeline)
+    return timeline
+  }
+
+  private async buildAndPersistTimelineWithBlueprint(rundown: Rundown): Promise<Timeline> {
     const onTimelineGenerateResult: OnTimelineGenerateResult = await this.buildTimelineAndCallOnGenerate(rundown)
     rundown.setPersistentState(onTimelineGenerateResult.rundownPersistentState)
     this.timelineRepository.saveTimeline(onTimelineGenerateResult.timeline)

--- a/src/model/entities/test/entity-mock-factory.ts
+++ b/src/model/entities/test/entity-mock-factory.ts
@@ -66,6 +66,7 @@ export class EntityMockFactory {
     when(mockedRundown.getActiveSegment()).thenReturn(activeRundownProperties.activeSegment ?? this.createSegment())
     when(mockedRundown.getNextSegment()).thenReturn(activeRundownProperties.nextSegment ?? this.createSegment())
     when(mockedRundown.getInfinitePieces()).thenReturn(activeRundownProperties.infinitePieces ?? [])
+    when(mockedRundown.isActivePartSet()).thenReturn(true)
 
     return mockedRundown
   }

--- a/src/model/value-objects/rundown-event.ts
+++ b/src/model/value-objects/rundown-event.ts
@@ -14,8 +14,6 @@ export interface PartEvent extends RundownEvent {
 
 export interface RundownActivatedEvent extends RundownEvent {
   type: RundownEventType.ACTIVATED
-  segmentId: string
-  partId: string
 }
 
 export interface RundownDeactivatedEvent extends RundownEvent {


### PR DESCRIPTION
This PR is dependent on: https://github.com/tv2/sofie-server/pull/10
It also has breaking changes for the RundownActivatedEvent that has been fixed in: https://github.com/tv2/ng-sofie/pull/24

The Rundown no longer perfoms a Take on activation.
To achieve this, it has been necessary to make the active Part and active Segment on the Rundown optional.