### PR TITLE
Sof 1596/run mongodb as docker

### DIFF
--- a/mongodb/compose.yml
+++ b/mongodb/compose.yml
@@ -1,0 +1,15 @@
+services:
+  mongo:
+    container_name: 'sofie-mongo'
+    image: 'mongo:6.0.1'
+    command: ['--replSet', 'rs0', '--bind_ip_all']
+    ports:
+      - '3002:27017'
+    volumes:
+      - 'mongodata:/data/db'
+    healthcheck:
+      test: 'mongosh --eval "rs.initiate()"'
+      start_period: '5s'
+
+volumes:
+  mongodata:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node dist",
     "build": "tsc --build",
-    "watch": "nodemon",
+    "watch": "yarn start-mongo && nodemon",
     "test": "jest",
     "test-watch": "jest --watch --coverage",
     "lint": "eslint --ext .ts .",
@@ -14,7 +14,8 @@
     "validate": "yarn audit --level moderate --groups dependencies",
     "clean": "rimraf dist",
     "reset": "rimraf dist node_modules coverage *.log",
-    "start-mongo": "docker-compose -f ./mongodb/compose.yml up"
+    "start-mongo": "docker-compose -f ./mongodb/compose.yml up -d",
+    "stop-mongo": "docker-compose -f ./mongodb/compose.yml down"
   },
   "devDependencies": {
     "@types/cors": "^2.8.14",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint-fix": "eslint --fix --ext .ts .",
     "validate": "yarn audit --level moderate --groups dependencies",
     "clean": "rimraf dist",
-    "reset": "rimraf dist node_modules coverage *.log"
+    "reset": "rimraf dist node_modules coverage *.log",
+    "start-mongo": "docker-compose -f ./mongodb/compose.yml up"
   },
   "devDependencies": {
     "@types/cors": "^2.8.14",

--- a/src/data-access/repositories/interfaces/configuration-repository.ts
+++ b/src/data-access/repositories/interfaces/configuration-repository.ts
@@ -3,3 +3,4 @@ import { Configuration } from '../../../model/entities/configuration'
 export interface ConfigurationRepository {
   getConfiguration(): Promise<Configuration>
 }
+

--- a/src/data-access/repositories/mongo/mongo-database.ts
+++ b/src/data-access/repositories/mongo/mongo-database.ts
@@ -3,8 +3,8 @@ import { Collection } from 'mongodb'
 import { DatabaseNotConnectedException } from '../../../model/exceptions/database-not-connected-exception'
 
 // TODO: Move to ENV variables
-const MONGO_CONNECTION_STRING: string = 'mongodb://localhost:3001'
-const MONGO_DB_NAME: string = 'meteor'
+const MONGO_CONNECTION_STRING: string = 'mongodb://localhost:3002'
+const MONGO_DB_NAME: string = 'sofie'
 
 export class MongoDatabase {
   private static instance: MongoDatabase
@@ -21,7 +21,7 @@ export class MongoDatabase {
 
   private constructor() {
     this.connectToDatabase()
-      .catch(() => console.error('Failed connecting to mongo database.'))
+      .catch((error) => console.error('Failed connecting to mongo database.', MONGO_CONNECTION_STRING, error))
   }
 
   private async connectToDatabase(): Promise<void> {
@@ -30,7 +30,7 @@ export class MongoDatabase {
       return
     }
 
-    this.client = new mongodb.MongoClient(MONGO_CONNECTION_STRING)
+    this.client = new mongodb.MongoClient(MONGO_CONNECTION_STRING, { replicaSet: 'rs0', directConnection: true })
     await this.client.connect()
 
     this.db = this.client.db(MONGO_DB_NAME)


### PR DESCRIPTION
- `yarn start-mongo`  start a mongo instance on port 3002.
- `yarn stop-mongo` stops the instance.
- `yarn watch` calls `yarn start-mongo` prior to starting watching.
- Connects to database on port 3002 with directConnection set to true.

Cause of changing it to draft: There seems to be some instability in how it can be used. The PR should be merged when it is stable.