### PR TITLE
Expose Rundown Cursor information on piece inserted event

### DIFF
--- a/src/business-logic/services/interfaces/rundown-event-emitter.ts
+++ b/src/business-logic/services/interfaces/rundown-event-emitter.ts
@@ -11,6 +11,6 @@ export interface RundownEventEmitter {
   emitDeletedEvent(rundown: Rundown): void
   emitPartInsertedAsOnAirEvent(rundown: Rundown, part: Part): void
   emitPartInsertedAsNextEvent(rundown: Rundown, part: Part): void
-  emitPieceInsertedEvent(rundown: Rundown, piece: Piece): void
+  emitPieceInsertedEvent(rundown: Rundown, segmentId: string, piece: Piece): void
   emitInfiniteRundownPieceAddedEvent(rundown: Rundown, infinitePiece: Piece): void
 }

--- a/src/business-logic/services/rundown-timeline-service.ts
+++ b/src/business-logic/services/rundown-timeline-service.ts
@@ -206,7 +206,8 @@ export class RundownTimelineService implements RundownService {
 
     await this.buildAndPersistTimeline(rundown)
 
-    this.rundownEventEmitter.emitPieceInsertedEvent(rundown, piece)
+    const segmentId: string = rundown.getActiveSegment().id
+    this.rundownEventEmitter.emitPieceInsertedEvent(rundown, segmentId, piece)
 
     await this.rundownRepository.saveRundown(rundown)
   }
@@ -217,7 +218,8 @@ export class RundownTimelineService implements RundownService {
 
     await this.buildAndPersistTimeline(rundown)
 
-    this.rundownEventEmitter.emitPieceInsertedEvent(rundown, piece)
+    const segmentId: string = rundown.getNextSegment().id
+    this.rundownEventEmitter.emitPieceInsertedEvent(rundown, segmentId, piece)
 
     await this.rundownRepository.saveRundown(rundown)
   }

--- a/src/model/entities/part.ts
+++ b/src/model/entities/part.ts
@@ -94,8 +94,7 @@ export class Part {
 
   public takeOffAir(): void {
     this.isPartOnAir = false
-    // TODO: Correct the flow such that we don't take offAir when executedAt is 0.
-    this.playedDuration = this.executedAt === 0 ? 0 : Date.now() - this.executedAt
+    this.playedDuration = Date.now() - this.executedAt
   }
 
   public isOnAir(): boolean {

--- a/src/model/entities/rundown.ts
+++ b/src/model/entities/rundown.ts
@@ -420,7 +420,7 @@ export class Rundown extends BasicRundown {
       this.nextSegment = this.findSegment(segmentId)
       this.markNextSegment()
     }
-    this.removeUnplannedPiecesFromNextPart()
+    this.nextPart?.reset()
     this.unmarkNextPart()
     this.nextPart = this.nextSegment.findPart(partId)
     this.markNextPart()
@@ -432,10 +432,6 @@ export class Rundown extends BasicRundown {
       throw new NotFoundException(`Segment "${segmentId}" does not exist in Rundown "${this.id}"`)
     }
     return segment
-  }
-
-  private removeUnplannedPiecesFromNextPart(): void {
-    this.nextPart?.reset()
   }
 
   public setSegments(segments: Segment[]): void {

--- a/src/model/entities/rundown.ts
+++ b/src/model/entities/rundown.ts
@@ -420,7 +420,7 @@ export class Rundown extends BasicRundown {
       this.nextSegment = this.findSegment(segmentId)
       this.markNextSegment()
     }
-
+    this.removeUnplannedPiecesFromNextPart()
     this.unmarkNextPart()
     this.nextPart = this.nextSegment.findPart(partId)
     this.markNextPart()
@@ -432,6 +432,10 @@ export class Rundown extends BasicRundown {
       throw new NotFoundException(`Segment "${segmentId}" does not exist in Rundown "${this.id}"`)
     }
     return segment
+  }
+
+  private removeUnplannedPiecesFromNextPart(): void {
+    this.nextPart?.reset()
   }
 
   public setSegments(segments: Segment[]): void {

--- a/src/model/entities/test/rundown.spec.ts
+++ b/src/model/entities/test/rundown.spec.ts
@@ -2210,4 +2210,29 @@ describe(Rundown.name, () => {
       verify(mockedSegment3.reset()).once()
     })
   })
+
+  describe(Rundown.prototype.setNext.name, () => {
+    it('resets next part right before changing next cursor', () => {
+      const mockedNextPart: Part = EntityMockFactory.createPartMock({ isNext: true })
+      const nextPart: Part = instance(mockedNextPart)
+      const nextSegment: Segment = EntityMockFactory.createSegment({ isNext: true, parts: [nextPart] })
+      const activePart: Part = EntityMockFactory.createPart({ isOnAir: true })
+      const otherPartInActiveSegment: Part = EntityMockFactory.createPart()
+      const activeSegment: Segment = EntityMockFactory.createSegment({ isOnAir: true, parts: [activePart, otherPartInActiveSegment] })
+      const testee: Rundown = new Rundown({
+        isRundownActive: true,
+        alreadyActiveProperties: {
+          activeSegment,
+          activePart,
+          nextSegment,
+          nextPart: instance(mockedNextPart),
+          infinitePieces: new Map(),
+        },
+      } as RundownInterface)
+
+      testee.setNext(activeSegment.id, otherPartInActiveSegment.id)
+
+      verify(mockedNextPart.reset()).once()
+    })
+  })
 })

--- a/src/presentation/dtos/piece-dto.ts
+++ b/src/presentation/dtos/piece-dto.ts
@@ -8,6 +8,7 @@ export class PieceDto {
   public readonly duration: number
   public readonly layer: string
   public readonly type: string
+  public readonly isPlanned: boolean
 
   constructor(piece: Piece) {
     this.id = piece.id
@@ -17,5 +18,6 @@ export class PieceDto {
     this.duration = piece.duration
     this.layer = piece.layer
     this.type = piece.type
+    this.isPlanned = piece.isPlanned
   }
 }

--- a/src/presentation/interfaces/rundown-event-builder.ts
+++ b/src/presentation/interfaces/rundown-event-builder.ts
@@ -23,6 +23,6 @@ export interface RundownEventBuilder {
   buildDeletedEvent(rundown: Rundown): RundownDeletedEvent
   buildPartInsertedAsOnAirEvent(rundown: Rundown, part: Part): PartInsertedAsOnAirEvent
   buildPartInsertedAsNextEvent(rundown: Rundown, part: Part): PartInsertedAsNextEvent
-  buildPieceInsertedEvent(rundown: Rundown, piece: Piece): PieceInsertedEvent
+  buildPieceInsertedEvent(rundown: Rundown, segmentId: string, piece: Piece): PieceInsertedEvent
   buildInfiniteRundownPieceAddedEvent(rundown: Rundown, infinitePiece: Piece): RundownInfinitePieceAddedEvent
 }

--- a/src/presentation/services/rundown-event-builder-implementation.ts
+++ b/src/presentation/services/rundown-event-builder-implementation.ts
@@ -99,11 +99,13 @@ export class RundownEventBuilderImplementation implements RundownEventBuilder {
 
   }
 
-  public buildPieceInsertedEvent(rundown: Rundown, piece: Piece): PieceInsertedEvent {
+  public buildPieceInsertedEvent(rundown: Rundown, segmentId: string, piece: Piece): PieceInsertedEvent {
     return {
       type: RundownEventType.PIECE_INSERTED,
       timestamp: Date.now(),
       rundownId: rundown.id,
+      segmentId,
+      partId: piece.getPartId(),
       piece: new PieceDto(piece)
     }
   }

--- a/src/presentation/services/rundown-event-service.ts
+++ b/src/presentation/services/rundown-event-service.ts
@@ -62,8 +62,8 @@ export class RundownEventService implements RundownEventEmitter, RundownEventLis
     this.emitRundownEvent(event)
   }
 
-  public emitPieceInsertedEvent(rundown: Rundown, piece: Piece): void {
-    const event: PieceInsertedEvent = this.rundownEventBuilder.buildPieceInsertedEvent(rundown, piece)
+  public emitPieceInsertedEvent(rundown: Rundown, segmentId: string, piece: Piece): void {
+    const event: PieceInsertedEvent = this.rundownEventBuilder.buildPieceInsertedEvent(rundown, segmentId, piece)
     this.emitRundownEvent(event)
   }
 

--- a/src/presentation/value-objects/rundown-event.ts
+++ b/src/presentation/value-objects/rundown-event.ts
@@ -47,7 +47,7 @@ export interface PartInsertedAsNextEvent extends RundownEvent {
   part: PartDto
 }
 
-export interface PieceInsertedEvent extends RundownEvent {
+export interface PieceInsertedEvent extends PartEvent {
   type: RundownEventType.PIECE_INSERTED,
   piece: PieceDto
 }


### PR DESCRIPTION
- Added segment id, and part id to piece inserted event, to have the rundown cursor data present as in the other part related events.
- Resets part right before changing next cursor to remove unplanned pieces.