### PR TITLE
fix(tv2-blueprints): The name for camera actions inserted as next has PVW suffixed.

### DIFF
--- a/src/blueprints/tv2/factories/tv2-camera-action-factory.ts
+++ b/src/blueprints/tv2/factories/tv2-camera-action-factory.ts
@@ -31,8 +31,8 @@ export class Tv2CameraActionFactory {
     const partInterface: PartInterface = this.createPartInterface(partId, cameraSource)
     return {
       id: `cameraAsNextAction_${cameraSource._id}`,
-      name: `KAM ${cameraSource.SourceName}`,
-      description: `Insert Camera ${cameraSource.SourceName}`,
+      name: `KAM ${cameraSource.SourceName} PVW`,
+      description: `Insert Camera ${cameraSource.SourceName} as next.`,
       type: PartActionType.INSERT_PART_AS_NEXT,
       data: {
         partInterface: partInterface,
@@ -195,7 +195,7 @@ export class Tv2CameraActionFactory {
     return {
       id: `cameraAsOnAirAction_${cameraSource._id}`,
       name: `KAM ${cameraSource.SourceName}`,
-      description: `Insert and Take Camera ${cameraSource.SourceName}`,
+      description: `Insert and Take Camera ${cameraSource.SourceName}.`,
       type: PartActionType.INSERT_PART_AS_ON_AIR,
       data: {
         partInterface: partInterface,


### PR DESCRIPTION
The name for camera actions inserted as next has PVW suffixed.