### PR TITLE
SOF-1628 User source.SourceName instead of _id for Remote Actions

### DIFF
--- a/src/blueprints/tv2/action-factories/tv2-remote-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-remote-action-factory.ts
@@ -46,11 +46,11 @@ export class Tv2RemoteActionFactory {
   }
 
   private createInsertRemoteAsNextAction(configuration: Tv2BlueprintConfiguration, remoteSource: Tv2SourceMappingWithSound): Tv2RemoteAction {
-    const partId: string = `remoteInsertActionPart_${remoteSource._id}`
+    const partId: string = `remoteInsertActionPart_${remoteSource.SourceName}`
     const remotePieceInterface: PieceInterface = this.createRemotePiece(configuration, remoteSource, partId)
     const partInterface: PartInterface = this.createPartInterface(partId, remoteSource)
     return {
-      id: `remoteAsNextAction_${remoteSource._id}`,
+      id: `remoteAsNextAction_${remoteSource.SourceName}`,
       name: `LIVE ${remoteSource.SourceName}`,
       description: `Insert LIVE ${remoteSource.SourceName} as next.`,
       type: PartActionType.INSERT_PART_AS_NEXT,


### PR DESCRIPTION
`Tv2SourceMappingWithSound._id` is the id created by MongoDB. `.SourceName` is currently the number 1 through 5. 
This is to use the number so the Action is more recognizable