### PR TITLE
(SOF-1692) Only generate/return general and specified rundown actions

### DIFF
--- a/src/blueprints/tv2/action-factories/tv2-dve-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-dve-action-factory.ts
@@ -374,6 +374,7 @@ export class Tv2DveActionFactory {
       return {
         id: `plannedDveAsNextAction_${data.name.replace(/\s/g, '')}`,
         name: data.template,
+        rundownId: data.rundownId,
         description: '',
         type: PartActionType.INSERT_PART_AS_NEXT,
         metadata: {

--- a/src/blueprints/tv2/action-factories/tv2-graphics-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-graphics-action-factory.ts
@@ -252,6 +252,7 @@ export class Tv2GraphicsActionFactory {
     return {
       id: `fullscreen_graphics_${this.stringHashConverter.getHashedValue(fullscreenGraphicsData.name)}`,
       name: `Fullscreen Graphics - ${fullscreenGraphicsData.name}`,
+      rundownId: fullscreenGraphicsData.rundownId,
       type: PartActionType.INSERT_PART_AS_NEXT,
       data: {
         partInterface: partInterface,
@@ -474,8 +475,9 @@ export class Tv2GraphicsActionFactory {
     })
     return {
       id: `ident_${this.stringHashConverter.getHashedValue(overlayGraphicsData.name)}`,
-      type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       name: overlayGraphicsData.name,
+      rundownId: overlayGraphicsData.rundownId,
+      type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
         pieceInterface
       },
@@ -513,8 +515,9 @@ export class Tv2GraphicsActionFactory {
 
     return {
       id: `lower_third_${this.stringHashConverter.getHashedValue(overlayGraphicsData.name)}`,
-      type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       name: overlayGraphicsData.name,
+      rundownId: overlayGraphicsData.rundownId,
+      type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
         pieceInterface
       },

--- a/src/blueprints/tv2/action-factories/tv2-video-clip-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-video-clip-action-factory.ts
@@ -81,6 +81,7 @@ export class Tv2VideoClipActionFactory {
     return {
       id: `videoClipAsNextAction_${videoClipData.fileName}`,
       name: videoClipData.name,
+      rundownId: videoClipData.rundownId,
       type: PartActionType.INSERT_PART_AS_NEXT,
       data: {
         partInterface,

--- a/src/blueprints/tv2/tv2-action-service.ts
+++ b/src/blueprints/tv2/tv2-action-service.ts
@@ -91,6 +91,7 @@ export class Tv2ActionService implements BlueprintGenerateActions {
       .map(actionManifest => {
         const data: Tv2ActionManifestDataForFullscreenGraphics = actionManifest.data
         return {
+          rundownId: actionManifest.rundownId,
           name: data.name,
           vcpId: data.vcpid,
         }
@@ -103,6 +104,7 @@ export class Tv2ActionService implements BlueprintGenerateActions {
       .map(actionManifest => {
         const data: Tv2ActionManifestDataForOverlayGraphics = actionManifest.data
         return {
+          rundownId: actionManifest.rundownId,
           name: data.name,
           sourceLayerId: data.sourceLayerId,
           templateName: this.getTemplateName(data.name),
@@ -126,6 +128,7 @@ export class Tv2ActionService implements BlueprintGenerateActions {
       .map(actionManifest => {
         const data: Tv2ActionManifestDataForVideoClip = actionManifest.data
         return {
+          rundownId: actionManifest.rundownId,
           name: data.partDefinition.storyName,
           fileName: data.partDefinition.fields.videoId,
           durationFromIngest: data.duration,
@@ -166,6 +169,7 @@ export class Tv2ActionService implements BlueprintGenerateActions {
         const data: Tv2ActionManifestDataForDve = actionManifest.data
         const sources: Map<DveBoxInput, Tv2SourceMappingWithSound> = this.getDveSourcesFromActionManifestData(data, blueprintConfiguration)
         return {
+          rundownId: actionManifest.rundownId,
           name: data.name,
           template: data.config.template,
           sources

--- a/src/blueprints/tv2/value-objects/tv2-action-manifest-data.ts
+++ b/src/blueprints/tv2/value-objects/tv2-action-manifest-data.ts
@@ -83,9 +83,11 @@ export interface Tv2VideoClipManifestData {
   durationFromIngest: number // userData.duration
   adLibPix: boolean // userData.adLibPix // What does "adLibPix" mean?
   audioMode: Tv2AudioMode // userData.voLevels
+  rundownId?: string
 }
 
 export interface Tv2DveManifestData {
+  rundownId: string
   name: string,
   template: string,
   sources: Map<DveBoxInput, Tv2SourceMappingWithSound>
@@ -94,11 +96,13 @@ export interface Tv2DveManifestData {
 export type Tv2GraphicsManifestData = Tv2FullscreenGraphicsManifestData | Tv2OverlayGraphicsManifestData
 
 export interface Tv2FullscreenGraphicsManifestData {
+  rundownId: string
   vcpId: number
   name: string,
 }
 
 export interface Tv2OverlayGraphicsManifestData {
+  rundownId: string
   sourceLayerId: Tv2SourceLayer
   name: string,
   templateName: string

--- a/src/business-logic/services/execute-action-service.ts
+++ b/src/business-logic/services/execute-action-service.ts
@@ -36,10 +36,9 @@ export class ExecuteActionService implements ActionService {
     private readonly blueprint: Blueprint
   ) {}
 
-  public async getActions(): Promise<Action[]> {
+  public async getActions(rundownId: string): Promise<Action[]> {
     const configuration: Configuration = await this.configurationRepository.getConfiguration()
-    // TODO: Only fetch ActionManifest for a given Rundown
-    const actionManifests: ActionManifest[] = await this.actionManifestRepository.getActionManifests()
+    const actionManifests: ActionManifest[] = await this.actionManifestRepository.getActionManifests(rundownId)
     // TODO: The Actions should be generated on ingest. Move them once we control ingest.
     const actions: Action[] = this.blueprint.generateActions(configuration, actionManifests)
     await this.actionRepository.saveActions(actions)

--- a/src/business-logic/services/interfaces/action-service.ts
+++ b/src/business-logic/services/interfaces/action-service.ts
@@ -1,6 +1,6 @@
 import { Action } from '../../../model/entities/action'
 
 export interface ActionService {
-  getActions(): Promise<Action[]>
+  getActions(rundownId: string): Promise<Action[]>
   executeAction(actionId: string, rundownId: string): Promise<void>
 }

--- a/src/data-access/repositories/interfaces/action-manifest-repository.ts
+++ b/src/data-access/repositories/interfaces/action-manifest-repository.ts
@@ -1,5 +1,5 @@
 import { ActionManifest } from '../../../model/entities/action'
 
 export interface ActionManifestRepository {
-  getActionManifests(): Promise<ActionManifest[]>
+  getActionManifests(rundownId: string): Promise<ActionManifest[]>
 }

--- a/src/data-access/repositories/mongo/mongo-action-manifest-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-action-manifest-repository.ts
@@ -6,10 +6,10 @@ export class MongoActionManifestRepository implements ActionManifestRepository {
   constructor(private readonly actionManifestRepositories: ActionManifestRepository[]) {
   }
 
-  public async getActionManifests(): Promise<ActionManifest[]> {
+  public async getActionManifests(rundownId: string): Promise<ActionManifest[]> {
     const actionManifests: ActionManifest[] = []
     for (const repository of this.actionManifestRepositories) {
-      actionManifests.push(...(await repository.getActionManifests()))
+      actionManifests.push(...(await repository.getActionManifests(rundownId)))
     }
     return actionManifests
   }

--- a/src/data-access/repositories/mongo/mongo-ad-lib-actions-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-ad-lib-actions-repository.ts
@@ -24,7 +24,7 @@ export class MongoAdLibActionsRepository extends BaseMongoRepository implements 
   public async getActionManifests(rundownId: string): Promise<ActionManifest[]> {
     this.assertDatabaseConnection(this.getActionManifests.name)
     const adLibActions: AdLibAction[] = await this.getCollection().find<AdLibAction>({rundownId: rundownId}).toArray()
-    return adLibActions.filter(action => action.rundownId === rundownId).map(adLibAction => this.mapToActionManifest(adLibAction))
+    return adLibActions.map(adLibAction => this.mapToActionManifest(adLibAction))
   }
 
   private mapToActionManifest(adLibAction: AdLibAction): ActionManifest {

--- a/src/data-access/repositories/mongo/mongo-ad-lib-actions-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-ad-lib-actions-repository.ts
@@ -8,6 +8,7 @@ const AD_LIB_ACTIONS_COLLECTION: string = 'adLibActions'
 
 interface AdLibAction {
   actionId: string
+  rundownId: string
   userData: unknown
 }
 export class MongoAdLibActionsRepository extends BaseMongoRepository implements ActionManifestRepository {
@@ -20,15 +21,16 @@ export class MongoAdLibActionsRepository extends BaseMongoRepository implements 
     return AD_LIB_ACTIONS_COLLECTION
   }
 
-  public async getActionManifests(): Promise<ActionManifest[]> {
+  public async getActionManifests(rundownId: string): Promise<ActionManifest[]> {
     this.assertDatabaseConnection(this.getActionManifests.name)
-    const adLibActions: AdLibAction[] = await this.getCollection().find<AdLibAction>({}).toArray()
-    return adLibActions.map(adLibAction => this.mapToActionManifest(adLibAction))
+    const adLibActions: AdLibAction[] = await this.getCollection().find<AdLibAction>({rundownId: rundownId}).toArray()
+    return adLibActions.filter(action => action.rundownId === rundownId).map(adLibAction => this.mapToActionManifest(adLibAction))
   }
 
   private mapToActionManifest(adLibAction: AdLibAction): ActionManifest {
     return {
       actionId: adLibAction.actionId,
+      rundownId: adLibAction.rundownId,
       data: adLibAction.userData
     }
   }

--- a/src/data-access/repositories/mongo/mongo-ad-lib-piece-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-ad-lib-piece-repository.ts
@@ -8,6 +8,7 @@ const AD_LIB_PIECES_COLLECTION: string = 'adLibPieces'
 
 interface AdLibPiece {
   sourceLayerId: string
+  rundownId: string
   name: string
   expectedDuration: number | null
 }
@@ -21,16 +22,19 @@ export class MongoAdLibPieceRepository extends BaseMongoRepository implements Ac
     return AD_LIB_PIECES_COLLECTION
   }
 
-  public async getActionManifests(): Promise<ActionManifest[]> {
+  public async getActionManifests(rundownId: string): Promise<ActionManifest[]> {
     this.assertDatabaseConnection(this.getActionManifests.name)
     // Todo: The filter is Tv2 specific. Remove filtering when we control ingest.
-    const mongoAdLibPieces: AdLibPiece[] = await this.getCollection().find<AdLibPiece>({uniquenessId: {$not: { $regex: '.*_commentator$'}}}).toArray()
+    const mongoAdLibPieces: AdLibPiece[] = await this.getCollection().find<AdLibPiece>({
+      rundownId: rundownId, uniquenessId: {$not: { $regex: '.*_commentator$'}}
+    }).toArray()
     return mongoAdLibPieces.map(adLibPiece => this.mapToActionManifest(adLibPiece))
   }
 
   private mapToActionManifest(adLibPiece: AdLibPiece): ActionManifest {
     return {
       actionId: adLibPiece.sourceLayerId,
+      rundownId: adLibPiece.rundownId,
       data: {
         name: adLibPiece.name,
         expectedDuration: adLibPiece.expectedDuration ?? undefined,

--- a/src/model/entities/action.ts
+++ b/src/model/entities/action.ts
@@ -11,6 +11,10 @@ export interface Action {
   type: ActionType
   data: unknown
   metadata?: unknown
+  /**
+   * Undefined means the action is a general one. Having a value means the action is for that specific rundown.
+   * */
+  rundownId?: string
 }
 
 export interface PartAction extends Action {
@@ -67,5 +71,6 @@ export interface MutateActionWithHistoricPartMethods {
  */
 export interface ActionManifest<Data = unknown> {
   actionId: string
+  rundownId: string
   data: Data
 }

--- a/src/presentation/controllers/action-controller.ts
+++ b/src/presentation/controllers/action-controller.ts
@@ -14,9 +14,10 @@ export class ActionController extends BaseController {
   }
 
   @GetRequest('/rundowns/:rundownId')
-  public async getActions(_reg: Request, res: Response): Promise<void> {
+  public async getActions(reg: Request, res: Response): Promise<void> {
     try {
-      const actions: Action[] = await this.actionService.getActions()
+      const rundownId: string = reg.params.rundownId
+      const actions: Action[] = await this.actionService.getActions(rundownId)
       res.send(actions.map(action => new ActionDto(action)))
     } catch (error) {
       this.httpErrorHandler.handleError(res, error as Exception)

--- a/src/presentation/controllers/action-controller.ts
+++ b/src/presentation/controllers/action-controller.ts
@@ -14,9 +14,9 @@ export class ActionController extends BaseController {
   }
 
   @GetRequest('/rundowns/:rundownId')
-  public async getActions(reg: Request, res: Response): Promise<void> {
+  public async getActions(req: Request, res: Response): Promise<void> {
     try {
-      const rundownId: string = reg.params.rundownId
+      const rundownId: string = req.params.rundownId
       const actions: Action[] = await this.actionService.getActions(rundownId)
       res.send(actions.map(action => new ActionDto(action)))
     } catch (error) {
@@ -25,10 +25,10 @@ export class ActionController extends BaseController {
   }
 
   @PutRequest('/:actionId/rundowns/:rundownId')
-  public async executeAction(reg: Request, res: Response): Promise<void> {
+  public async executeAction(req: Request, res: Response): Promise<void> {
     try {
-      const actionId: string = reg.params.actionId
-      const rundownId: string = reg.params.rundownId
+      const actionId: string = req.params.actionId
+      const rundownId: string = req.params.rundownId
       await this.actionService.executeAction(actionId, rundownId)
       res.send(`Successfully executed action: ${actionId} on Rundown: ${rundownId}`)
     } catch (error) {


### PR DESCRIPTION
NOTE: The target branch for this PR is the branch for #28. Reviewing that one before this is adviced. 

- Adds filtering of AdLibPieces/AdLibActions extracted from database, to only be the ones for the requested rundownId.
- Adds rundownId to actions generated from ActionManifests.

Has been tested locally, ensureing that only actions for the specified rundownId is returned.
Let me know if there are other actions being generated, that are rundown specific, other than those generated from ActionManifests.