### PR TITLE
(SOF-1691) Delete rundown actions before saving new ones.

### DIFF
--- a/src/business-logic/services/execute-action-service.ts
+++ b/src/business-logic/services/execute-action-service.ts
@@ -41,6 +41,7 @@ export class ExecuteActionService implements ActionService {
     const actionManifests: ActionManifest[] = await this.actionManifestRepository.getActionManifests(rundownId)
     // TODO: The Actions should be generated on ingest. Move them once we control ingest.
     const actions: Action[] = this.blueprint.generateActions(configuration, actionManifests)
+    await this.actionRepository.deleteRundownActions(rundownId)
     await this.actionRepository.saveActions(actions)
     return actions
   }

--- a/src/business-logic/services/execute-action-service.ts
+++ b/src/business-logic/services/execute-action-service.ts
@@ -41,7 +41,7 @@ export class ExecuteActionService implements ActionService {
     const actionManifests: ActionManifest[] = await this.actionManifestRepository.getActionManifests(rundownId)
     // TODO: The Actions should be generated on ingest. Move them once we control ingest.
     const actions: Action[] = this.blueprint.generateActions(configuration, actionManifests)
-    await this.actionRepository.deleteRundownActions(rundownId)
+    await this.actionRepository.deleteActionsForRundown(rundownId)
     await this.actionRepository.saveActions(actions)
     return actions
   }

--- a/src/data-access/repositories/interfaces/action-repository.ts
+++ b/src/data-access/repositories/interfaces/action-repository.ts
@@ -3,4 +3,5 @@ import { Action } from '../../../model/entities/action'
 export interface ActionRepository {
   getAction(actionId: string): Promise<Action>
   saveActions(actions: Action[]): Promise<void>
+  deleteRundownActions(rundownId: string): Promise<void>
 }

--- a/src/data-access/repositories/interfaces/action-repository.ts
+++ b/src/data-access/repositories/interfaces/action-repository.ts
@@ -3,5 +3,5 @@ import { Action } from '../../../model/entities/action'
 export interface ActionRepository {
   getAction(actionId: string): Promise<Action>
   saveActions(actions: Action[]): Promise<void>
-  deleteRundownActions(rundownId: string): Promise<void>
+  deleteActionsForRundown(rundownId: string): Promise<void>
 }

--- a/src/data-access/repositories/mongo/mongo-action-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-action-repository.ts
@@ -32,8 +32,8 @@ export class MongoActionRepository extends BaseMongoRepository implements Action
     )
   }
 
-  public async deleteRundownActions(rundownId: string): Promise<void> {
-    this.assertDatabaseConnection(this.deleteRundownActions.name)
+  public async deleteActionsForRundown(rundownId: string): Promise<void> {
+    this.assertDatabaseConnection(this.deleteActionsForRundown.name)
     const actionsDeleteResult: DeleteResult = await this.getCollection().deleteMany({ rundownId: rundownId })
 
     if (!actionsDeleteResult.acknowledged) {

--- a/src/data-access/repositories/mongo/mongo-action-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-action-repository.ts
@@ -3,6 +3,8 @@ import { ActionRepository } from '../interfaces/action-repository'
 import { Action } from '../../../model/entities/action'
 import { MongoDatabase } from './mongo-database'
 import { MongoEntityConverter } from './mongo-entity-converter'
+import { DeleteResult } from 'mongodb'
+import { DeletionFailedException } from '../../../model/exceptions/deletion-failed-exception'
 
 const COLLECTION_NAME: string = 'actions'
 
@@ -17,14 +19,25 @@ export class MongoActionRepository extends BaseMongoRepository implements Action
   }
 
   public async getAction(actionId: string): Promise<Action> {
+    this.assertDatabaseConnection(this.getAction.name)
     return await this.getCollection().findOne({id: actionId}) as unknown as Action
   }
 
   public async saveActions(actions: Action[]): Promise<void> {
+    this.assertDatabaseConnection(this.saveActions.name)
     await Promise.all(
       actions.map(action =>
         this.getCollection().updateOne({ _id: action.id }, { $set: action }, { upsert: true, ignoreUndefined: true })
       )
     )
+  }
+
+  public async deleteRundownActions(rundownId: string): Promise<void> {
+    this.assertDatabaseConnection(this.deleteRundownActions.name)
+    const actionsDeleteResult: DeleteResult = await this.getCollection().deleteMany({ rundownId: rundownId })
+
+    if (!actionsDeleteResult.acknowledged) {
+      throw new DeletionFailedException(`Failed to delete Actions for Rundown: ${rundownId}`)
+    }
   }
 }

--- a/src/presentation/controllers/action-controller.ts
+++ b/src/presentation/controllers/action-controller.ts
@@ -14,9 +14,9 @@ export class ActionController extends BaseController {
   }
 
   @GetRequest('/rundowns/:rundownId')
-  public async getActions(reg: Request, res: Response): Promise<void> {
+  public async getActions(req: Request, res: Response): Promise<void> {
     try {
-      const rundownId: string = reg.params.rundownId
+      const rundownId: string = req.params.rundownId
       const actions: Action[] = await this.actionService.getActions(rundownId)
       res.send(actions.map(action => new ActionDto(action)))
     } catch (error) {
@@ -25,10 +25,10 @@ export class ActionController extends BaseController {
   }
 
   @PutRequest('/:actionId/rundowns/:rundownId')
-  public async executeAction(reg: Request, res: Response): Promise<void> {
+  public async executeAction(req: Request, res: Response): Promise<void> {
     try {
-      const actionId: string = reg.params.actionId
-      const rundownId: string = reg.params.rundownId
+      const actionId: string = req.params.actionId
+      const rundownId: string = req.params.rundownId
       await this.actionService.executeAction(actionId, rundownId)
       res.send(`Successfully executed action: ${actionId} on Rundown: ${rundownId}`)
     } catch (error) {


### PR DESCRIPTION
NOTE: The base of this is the branch for #48. Reviewing that one before this is adviced.

- Adds deletion of rundown specific actions, prior to saving newly generated ones.

Has been verified locally, that actions with the specified rundown id is the only actions being removed by the new call.