### PR TITLE
SOF-1703 Add classes='full' to VCP Piece so Ident won't take precedent

### DIFF
--- a/src/blueprints/tv2/action-factories/tv2-graphics-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-graphics-action-factory.ts
@@ -227,7 +227,7 @@ export class Tv2GraphicsActionFactory {
 
   private createFullscreenGraphicsPartInterface(graphicsData: Tv2FullscreenGraphicsManifestData, blueprintConfiguration: Tv2BlueprintConfiguration): PartInterface {
     return {
-      id: `fullscreenGraphicsPart_${graphicsData.name}`,
+      id: `fullscreenGraphicsPart_${this.stringHashConverter.getHashedValue(graphicsData.name)}`,
       rundownId: '',
       name: `Full ${graphicsData.name}`,
       segmentId: '',

--- a/src/blueprints/tv2/timeline-object-factories/tv2-viz-timeline-object-factory.ts
+++ b/src/blueprints/tv2/timeline-object-factories/tv2-viz-timeline-object-factory.ts
@@ -130,7 +130,8 @@ export class Tv2VizTimelineObjectFactory implements Tv2GraphicsCommandTimelineOb
         noAutoPreloading: false,
         channelName: EngineName.FULLSCREEN,
         ...this.getFullGraphicOutTransitionProperties(blueprintConfiguration)
-      }
+      },
+      classes: ['full'] // Due to how Idents are ingested by Blueprints, if this is omitted VCPs will disappear when being taken from an Ident.
     }
   }
 


### PR DESCRIPTION
Our Fullscreen Actions for Viz was missing a `classes=['full']`.

The `classes` attribute is used by the Timeline Resolver to determine enables and can be used like `enable: { while: '!.full' }` which means while there is no objects with the class "full", then put this on the Timeline.

All our Idents is ingested by Blueprints with the above enable. For some reason, if the VCP does not have the `classes=['full']` a command is send to Viz to clear the VCP when it's been taken from an Ident. (I am not entirely sure why, but the working theory is that the Ident clear command takes precedent, but having the class "full" somehow 'cancels' that precedent.)

Ideally, we would like to avoid using the `classes` attribute since it's an extra complication in the Timeline Resolving (it does have its usecases though), but that would be a Blueprints change, that we can do when we move the Ingest Part of Blueprints.