### PR TITLE
SOF-1769 Expose endpoint to fetch Actions without a RundownId

### DIFF
--- a/src/business-logic/services/execute-action-service.ts
+++ b/src/business-logic/services/execute-action-service.ts
@@ -37,7 +37,21 @@ export class ExecuteActionService implements ActionService {
     private readonly blueprint: Blueprint
   ) {}
 
-  public async getActions(rundownId: string): Promise<Action[]> {
+  /**
+   * Fetches all Actions that are not associated with a Rundown
+   */
+  public async getActions(): Promise<Action[]> {
+    const configuration: Configuration = await this.configurationRepository.getConfiguration()
+    // TODO: The Actions should be generated on ingest. Move them once we control ingest.
+    const actions: Action[] = this.blueprint.generateActions(configuration, [])
+    await this.actionRepository.saveActions(actions)
+    return actions
+  }
+
+  /**
+   * Fetches all Actions that are not associated with a Rundown plus all Rundown specific Actions for the parsed RundownId
+   */
+  public async getActionsForRundown(rundownId: string): Promise<Action[]> {
     const configuration: Configuration = await this.configurationRepository.getConfiguration()
     const actionManifests: ActionManifest[] = await this.actionManifestRepository.getActionManifests(rundownId)
     // TODO: The Actions should be generated on ingest. Move them once we control ingest.

--- a/src/business-logic/services/interfaces/action-service.ts
+++ b/src/business-logic/services/interfaces/action-service.ts
@@ -1,6 +1,7 @@
 import { Action } from '../../../model/entities/action'
 
 export interface ActionService {
-  getActions(rundownId: string): Promise<Action[]>
+  getActions(): Promise<Action[]>
+  getActionsForRundown(rundownId: string): Promise<Action[]>
   executeAction(actionId: string, rundownId: string, actionArguments: unknown): Promise<void>
 }

--- a/src/data-access/repositories/mongo/mongo-action-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-action-repository.ts
@@ -4,6 +4,7 @@ import { Action } from '../../../model/entities/action'
 import { MongoDatabase } from './mongo-database'
 import { DeleteResult } from 'mongodb'
 import { DeletionFailedException } from '../../../model/exceptions/deletion-failed-exception'
+import { NotFoundException } from '../../../model/exceptions/not-found-exception'
 
 const COLLECTION_NAME: string = 'actions'
 
@@ -19,7 +20,11 @@ export class MongoActionRepository extends BaseMongoRepository implements Action
 
   public async getAction(actionId: string): Promise<Action> {
     this.assertDatabaseConnection(this.getAction.name)
-    return await this.getCollection().findOne({id: actionId}) as unknown as Action
+    const action: Action | null = await this.getCollection().findOne<Action>({ id: actionId })
+    if (action === null) {
+      throw new NotFoundException(`No Action found for ActionId ${actionId}`)
+    }
+    return action
   }
 
   public async saveActions(actions: Action[]): Promise<void> {

--- a/src/presentation/controllers/action-controller.ts
+++ b/src/presentation/controllers/action-controller.ts
@@ -22,11 +22,21 @@ export class ActionController extends BaseController {
     super()
   }
 
+  @GetRequest()
+  public async getActions(_request: Request, response: Response): Promise<void> {
+    try {
+      const actions: Action[] = await this.actionService.getActions()
+      response.send(this.httpResponseFormatter.formatSuccessResponse(actions.map(action => new ActionDto(action))))
+    } catch (error) {
+      this.httpErrorHandler.handleError(response, error as Exception)
+    }
+  }
+
   @GetRequest('/rundowns/:rundownId')
-  public async getActions(request: Request, response: Response): Promise<void> {
+  public async getActionsForRundown(request: Request, response: Response): Promise<void> {
     try {
       const rundownId: string = request.params.rundownId
-      const actions: Action[] = await this.actionService.getActions(rundownId)
+      const actions: Action[] = await this.actionService.getActionsForRundown(rundownId)
       response.send(this.httpResponseFormatter.formatSuccessResponse(actions.map(action => new ActionDto(action))))
     } catch (error) {
       this.httpErrorHandler.handleError(response, error as Exception)


### PR DESCRIPTION
Now exposes an endpoint that can fetch all Actions without giving a RundownId. The endpoint won't return any Actions that are specific to a Rundown.