### PR TITLE
SOF-1754 - Reset configuration cache with an endpoint request

### DIFF
--- a/src/data-access/repositories/cache/cached-configuration-repository.ts
+++ b/src/data-access/repositories/cache/cached-configuration-repository.ts
@@ -21,4 +21,8 @@ export class CachedConfigurationRepository implements ConfigurationRepository {
     }
     return this.cachedConfiguration
   }
+
+  public clearConfigurationCache(): void {
+    this.cachedConfiguration = undefined
+  }
 }

--- a/src/data-access/repositories/interfaces/configuration-repository.ts
+++ b/src/data-access/repositories/interfaces/configuration-repository.ts
@@ -1,5 +1,6 @@
 import { Configuration } from '../../../model/entities/configuration'
 
 export interface ConfigurationRepository {
+  clearConfigurationCache(): void
   getConfiguration(): Promise<Configuration>
 }

--- a/src/data-access/repositories/mongo/mongo-configuration-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-configuration-repository.ts
@@ -4,6 +4,7 @@ import { StudioRepository } from '../interfaces/studio-repository'
 import { ShowStyleRepository } from '../interfaces/show-style-repository'
 import { ShowStyle } from '../../../model/entities/show-style'
 import { Studio } from '../../../model/entities/studio'
+import {UnsupportedOperationException} from '../../../model/exceptions/unsupported-operation-exception'
 
 // Sofie currently only uses one hardcoded studio.
 const STUDIO_ID: string = 'studio0'
@@ -16,6 +17,10 @@ export class MongoConfigurationRepository implements ConfigurationRepository {
     private readonly studioRepository: StudioRepository,
     private readonly showStyleRepository: ShowStyleRepository
   ) {
+  }
+
+  public clearConfigurationCache(): void {
+    throw new UnsupportedOperationException('Method not applicable.')
   }
 
   public async getConfiguration(): Promise<Configuration> {

--- a/src/data-access/repositories/test/configuration-controller.spec.ts
+++ b/src/data-access/repositories/test/configuration-controller.spec.ts
@@ -1,0 +1,39 @@
+import { instance, mock, verify } from '@typestrong/ts-mockito'
+import { ConfigurationRepository } from '../interfaces/configuration-repository'
+import { ConfigurationController } from '../../../presentation/controllers/configuration-controller'
+import { Request, Response } from 'express'
+import { ShowStyleVariantRepository } from '../interfaces/show-style-variant-repository'
+import { HttpErrorHandler } from '../../../presentation/interfaces/http-error-handler'
+import { HttpResponseFormatter } from '../../../presentation/interfaces/http-response-formatter'
+
+describe(ConfigurationController.name, () => {
+  describe(
+    ConfigurationController.prototype.clearConfigurationCache.name,
+    () => {
+      it('invokes repo method for clearing of configuration cache when posted', () => {
+        const mockRequest: Request = mock<Request>()
+        const mockResponse: Response = mock<Response>()
+        const mockConfigurationRepository: ConfigurationRepository =
+          mock<ConfigurationRepository>()
+        const mockShowStyleVariantRepository: ShowStyleVariantRepository =
+          mock<ShowStyleVariantRepository>()
+        const mockHttpErrorHandler: HttpErrorHandler = mock<HttpErrorHandler>()
+        const mockHttpResponseFormatter: HttpResponseFormatter =
+          mock<HttpResponseFormatter>()
+        const configurationController: ConfigurationController =
+          new ConfigurationController(
+            instance(mockConfigurationRepository),
+            instance(mockShowStyleVariantRepository),
+            instance(mockHttpErrorHandler),
+            instance(mockHttpResponseFormatter),
+          )
+
+        configurationController.clearConfigurationCache(
+          mockRequest,
+          mockResponse,
+        )
+        verify(mockConfigurationRepository.clearConfigurationCache()).once()
+      })
+    },
+  )
+})

--- a/src/data-access/repositories/test/mongo-configuration-repository.spec.ts
+++ b/src/data-access/repositories/test/mongo-configuration-repository.spec.ts
@@ -1,0 +1,18 @@
+import {instance, mock} from '@typestrong/ts-mockito'
+import {MongoConfigurationRepository} from '../mongo/mongo-configuration-repository'
+import {StudioRepository} from '../interfaces/studio-repository'
+import {ShowStyleRepository} from '../interfaces/show-style-repository'
+
+describe(MongoConfigurationRepository.name, () => {
+  describe(MongoConfigurationRepository.prototype.clearConfigurationCache.name, () => {
+    it('throws error when invoked', () => {
+      const mockStudioRepository: StudioRepository = mock<StudioRepository>()
+      const mockShowStyleRepository: ShowStyleRepository = mock<ShowStyleRepository>()
+      const aMongoConfigurationRepository: MongoConfigurationRepository = new MongoConfigurationRepository(
+        instance(mockStudioRepository),
+        instance(mockShowStyleRepository)
+      )
+      expect(() => aMongoConfigurationRepository.clearConfigurationCache()).toThrow('Method not applicable.')
+    })
+  })
+})

--- a/src/presentation/controllers/configuration-controller.ts
+++ b/src/presentation/controllers/configuration-controller.ts
@@ -1,4 +1,4 @@
-import { BaseController, GetRequest, RestController } from './base-controller'
+import { BaseController, GetRequest, PostRequest, RestController } from './base-controller'
 import { HttpErrorHandler } from '../interfaces/http-error-handler'
 import { Request, Response } from 'express'
 import { ConfigurationRepository } from '../../data-access/repositories/interfaces/configuration-repository'
@@ -38,6 +38,16 @@ export class ConfigurationController extends BaseController {
       const rundownId: string = request.params.rundownId
       const showStyleVariant: ShowStyleVariant = await this.showStyleVariantRepository.getShowStyleVariant(rundownId)
       response.send(this.httpResponseFormatter.formatSuccessResponse(showStyleVariant))
+    } catch (error) {
+      this.httpErrorHandler.handleError(response, error as Exception)
+    }
+  }
+
+  @PostRequest('/cache/clear')
+  public clearConfigurationCache(_request: Request, response: Response): void {
+    try {
+      this.configurationRepository.clearConfigurationCache()
+      response.send(this.httpResponseFormatter.formatSuccessResponse(null))
     } catch (error) {
       this.httpErrorHandler.handleError(response, error as Exception)
     }


### PR DESCRIPTION
note: implementation re-take-2 - replaces https://github.com/tv2/sofie-server/pull/76 due to commit history being rewritten badly in attempt to sign all my unsigned commits.

task: We should be able to reset configuration cache without restarting the application.
For this - here I'm adding endpoint that will set cached configuration to undefined.

Also a button in config page that performs POST request to the reset endpoint https://github.com/tv2/ng-sofie/pull/85

