### PR TITLE
Sof 1719/update segments with mini shelf

### DIFF
--- a/src/business-logic/services/ingested-entity-to-entity-mapper.ts
+++ b/src/business-logic/services/ingested-entity-to-entity-mapper.ts
@@ -53,6 +53,7 @@ export class IngestedEntityToEntityMapper {
       name: ingestedSegment.name,
       rank: ingestedSegment.rank,
       isHidden: ingestedSegment.isHidden,
+      metadata: ingestedSegment.metadata,
       isOnAir: false,
       isNext: false,
       isUnsynced: false,

--- a/src/business-logic/services/ingested-entity-to-entity-mapper.ts
+++ b/src/business-logic/services/ingested-entity-to-entity-mapper.ts
@@ -52,6 +52,7 @@ export class IngestedEntityToEntityMapper {
       rundownId: ingestedSegment.rundownId,
       name: ingestedSegment.name,
       rank: ingestedSegment.rank,
+      isHidden: ingestedSegment.isHidden,
       isOnAir: false,
       isNext: false,
       isUnsynced: false,

--- a/src/data-access/repositories/mongo/mongo-ad-lib-actions-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-ad-lib-actions-repository.ts
@@ -23,7 +23,7 @@ export class MongoAdLibActionsRepository extends BaseMongoRepository implements 
 
   public async getActionManifests(rundownId: string): Promise<ActionManifest[]> {
     this.assertDatabaseConnection(this.getActionManifests.name)
-    const adLibActions: AdLibAction[] = await this.getCollection().find<AdLibAction>({rundownId: rundownId}).toArray()
+    const adLibActions: AdLibAction[] = await this.getCollection().find<AdLibAction>({ rundownId }).toArray()
     return adLibActions.map(adLibAction => this.mapToActionManifest(adLibAction))
   }
 

--- a/src/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/src/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -57,6 +57,8 @@ export interface MongoSegment extends MongoId {
   rundownId: string
   name: string
   rank: number
+  isHidden: boolean
+  metadata?: unknown
   partIds: string[]
   isOnAir: boolean
   isNext: boolean
@@ -267,6 +269,8 @@ export class MongoEntityConverter {
       rundownId: segment.rundownId,
       name: segment.name,
       rank: segment.rank,
+      isHidden: segment.isHidden,
+      metadata: segment.metadata,
       partIds: segment.getParts().map(part => part.id),
       isOnAir: segment.isOnAir(),
       isNext: segment.isNext(),

--- a/src/data-access/repositories/mongo/mongo-ingested-entity-converter.ts
+++ b/src/data-access/repositories/mongo/mongo-ingested-entity-converter.ts
@@ -54,6 +54,7 @@ export interface MongoIngestedSegment extends MongoId {
   rundownId: string
   externalId: string
   isHidden: boolean
+  metaData?: unknown // This is the current spelling in the database from Core... TOD: Update when we control Ingest
   budgetDuration?: number
 }
 
@@ -159,6 +160,8 @@ export class MongoIngestedEntityConverter {
       rundownId: mongoSegment.rundownId,
       name: mongoSegment.name,
       rank: mongoSegment._rank,
+      isHidden: mongoSegment.isHidden,
+      metadata: mongoSegment.metaData,
       ingestedParts: [],
       budgetDuration: mongoSegment.budgetDuration ?? undefined
     }
@@ -166,7 +169,6 @@ export class MongoIngestedEntityConverter {
 
   public convertToIngestedSegments(mongoSegments: MongoIngestedSegment[]): IngestedSegment[] {
     return mongoSegments
-      .filter((segment) => !segment.isHidden)
       .map(this.convertToIngestedSegment)
   }
 

--- a/src/model/entities/ingested-segment.ts
+++ b/src/model/entities/ingested-segment.ts
@@ -5,6 +5,8 @@ export interface IngestedSegment {
   readonly rundownId: string
   readonly name: string
   readonly rank: number
+  readonly isHidden: boolean
+  readonly metadata?: unknown
   readonly budgetDuration?: number
   readonly ingestedParts: Readonly<IngestedPart[]>
 }

--- a/src/model/entities/rundown.ts
+++ b/src/model/entities/rundown.ts
@@ -1,7 +1,5 @@
 import { Segment } from './segment'
 import { Part } from './part'
-import { Exception } from '../exceptions/exception'
-import { ErrorCode } from '../enums/error-code'
 import { LastPartInSegmentException } from '../exceptions/last-part-in-segment-exception'
 import { NotFoundException } from '../exceptions/not-found-exception'
 import { NotActivatedException } from '../exceptions/not-activated-exception'
@@ -18,7 +16,7 @@ import { UnsupportedOperationException } from '../exceptions/unsupported-operati
 import { RundownCursor } from '../value-objects/rundown-cursor'
 import { Owner } from '../enums/owner'
 import { AlreadyExistException } from '../exceptions/already-exist-exception'
-import { LastSegmentInRundown } from '../exceptions/last-segment-in-rundown'
+import { LastSegmentInRundownException } from '../exceptions/last-segment-in-rundown-exception'
 import { NoPartInHistoryException } from '../exceptions/no-part-in-history-exception'
 import { OnAirException } from '../exceptions/on-air-exception'
 import { RundownTiming } from '../value-objects/rundown-timing'
@@ -119,10 +117,7 @@ export class Rundown extends BasicRundown {
 
   private findFirstSegment(): Segment {
     return this.segments
-      .filter(segment => this.isSegmentValidForRundownExecution(segment))
-      .reduce((previousSegment: Segment, currentSegment: Segment) => {
-        return previousSegment.rank < currentSegment.rank ? previousSegment : currentSegment
-      })
+      .filter(segment => this.isSegmentValidForRundownExecution(segment))[0]
   }
 
   private isSegmentValidForRundownExecution(segment: Segment): boolean {
@@ -141,7 +136,7 @@ export class Rundown extends BasicRundown {
       const nextSegment: Segment | undefined = this.segments.find(segment => segment.id === nextPart.getSegmentId())
       this.nextCursor = this.createCursor(this.nextCursor, { segment: nextSegment, part: nextPart, owner })
     } catch (exception) {
-      if ((exception as Exception).errorCode !== ErrorCode.LAST_PART_IN_SEGMENT) {
+      if (!(exception instanceof LastPartInSegmentException)) {
         throw exception
       }
       this.unmarkNextSegment()
@@ -151,7 +146,7 @@ export class Rundown extends BasicRundown {
         this.nextCursor = this.createCursor(this.nextCursor, { segment, part: segment.findFirstPart(), owner })
         this.markNextSegment()
       } catch (err) {
-        if ((err as Exception).errorCode !== ErrorCode.LAST_SEGMENT_IN_RUNDOWN) {
+        if (!(err instanceof LastSegmentInRundownException)) {
           throw err
         }
         // TODO: Notify about last Segment.
@@ -194,12 +189,13 @@ export class Rundown extends BasicRundown {
     if (activeSegmentIndex === -1) {
       throw new NotFoundException('Active Segment does not exist in Rundown')
     }
-    for (let i = activeSegmentIndex; i < this.segments.length - 1; i++) {
-      if (this.isSegmentValidForRundownExecution(this.segments[i + 1])) {
-        return this.segments[i + 1]
-      }
+
+    const nextValidSegment: Segment | undefined = this.segments.slice(activeSegmentIndex + 1).find(segment => this.isSegmentValidForRundownExecution(segment))
+    if (!nextValidSegment) {
+      throw new LastSegmentInRundownException(`Segment: ${this.activeCursor?.segment?.id} is the last valid Segment of Rundown: ${this.id}`)
     }
-    throw new LastSegmentInRundown(`Segment: ${this.activeCursor?.segment?.id} is the last Segment of Rundown: ${this.id}`)
+
+    return nextValidSegment
   }
 
   public deactivate(): void {

--- a/src/model/entities/rundown.ts
+++ b/src/model/entities/rundown.ts
@@ -116,8 +116,11 @@ export class Rundown extends BasicRundown {
   }
 
   private findFirstSegment(): Segment {
-    return this.segments
-      .filter(segment => this.isSegmentValidForRundownExecution(segment))[0]
+    const segment: Segment | undefined = this.segments.find(segment => this.isSegmentValidForRundownExecution(segment))
+    if (!segment) {
+      throw new NotFoundException(`Unable to find first valid Segment for Rundown ${this.id}`)
+    }
+    return segment
   }
 
   private isSegmentValidForRundownExecution(segment: Segment): boolean {
@@ -145,9 +148,9 @@ export class Rundown extends BasicRundown {
         const segment: Segment = this.findNextValidSegment()
         this.nextCursor = this.createCursor(this.nextCursor, { segment, part: segment.findFirstPart(), owner })
         this.markNextSegment()
-      } catch (err) {
-        if (!(err instanceof LastSegmentInRundownException)) {
-          throw err
+      } catch (error) {
+        if (!(error instanceof LastSegmentInRundownException)) {
+          throw error
         }
         // TODO: Notify about last Segment.
       }

--- a/src/model/entities/segment.ts
+++ b/src/model/entities/segment.ts
@@ -11,6 +11,8 @@ export interface SegmentInterface {
   rundownId: string
   name: string
   rank: number
+  isHidden: boolean
+  metadata?: unknown
   parts: Part[]
   isOnAir: boolean
   isNext: boolean
@@ -22,9 +24,11 @@ export interface SegmentInterface {
 export class Segment {
   public readonly id: string
   public readonly rundownId: string
-  public name: string
+  public readonly name: string
+  public readonly expectedDurationInMs?: number
+  public readonly isHidden: boolean
+  public readonly metadata?: unknown
   public rank: number
-  public expectedDurationInMs?: number
 
   private isSegmentOnAir: boolean
   private isSegmentNext: boolean
@@ -38,6 +42,8 @@ export class Segment {
     this.rundownId = segment.rundownId
     this.name = segment.name
     this.rank = segment.rank
+    this.isHidden = segment.isHidden
+    this.metadata = segment.metadata
     this.isSegmentOnAir = segment.isOnAir
     this.isSegmentNext = segment.isNext
     this.isSegmentUnsynced = segment.isUnsynced

--- a/src/model/entities/test/entity-mock-factory.ts
+++ b/src/model/entities/test/entity-mock-factory.ts
@@ -108,6 +108,7 @@ export class EntityMockFactory {
     when(mockedSegment.isNext()).thenReturn(segmentInterface.isNext ?? false)
     when(mockedSegment.isOnAir()).thenReturn(segmentInterface.isOnAir ?? false)
     when(mockedSegment.rank).thenReturn(segmentInterface.rank ?? 1)
+    when(mockedSegment.isHidden).thenReturn(segmentInterface.isHidden ?? false)
     when(mockedSegment.rundownId).thenReturn(segmentInterface.rundownId ?? 'rundownId')
     when(mockedSegment.getParts()).thenReturn(segmentInterface.parts ?? [])
 

--- a/src/model/exceptions/last-segment-in-rundown-exception.ts
+++ b/src/model/exceptions/last-segment-in-rundown-exception.ts
@@ -1,7 +1,7 @@
 import { Exception } from './exception'
 import { ErrorCode } from '../enums/error-code'
 
-export class LastSegmentInRundown extends Exception {
+export class LastSegmentInRundownException extends Exception {
   constructor(message: string) {
     super(ErrorCode.LAST_SEGMENT_IN_RUNDOWN, message)
   }

--- a/src/model/exceptions/last-segment-in-rundown.ts
+++ b/src/model/exceptions/last-segment-in-rundown.ts
@@ -3,6 +3,6 @@ import { ErrorCode } from '../enums/error-code'
 
 export class LastSegmentInRundown extends Exception {
   constructor(message: string) {
-    super(ErrorCode.LAST_PART_IN_SEGMENT, message)
+    super(ErrorCode.LAST_SEGMENT_IN_RUNDOWN, message)
   }
 }

--- a/src/presentation/dtos/segment-dto.ts
+++ b/src/presentation/dtos/segment-dto.ts
@@ -10,6 +10,8 @@ export class SegmentDto {
   public readonly isUntimed: boolean
   public readonly isUnsynced: boolean
   public readonly rank: number
+  public readonly isHidden: boolean
+  public readonly metadata?: unknown
   public readonly expectedDurationInMs?: number
   public readonly executedAtEpochTime?: number
   public readonly parts: PartDto[]
@@ -23,6 +25,8 @@ export class SegmentDto {
     this.isUntimed = segment.isSegmentUntimed()
     this.isUnsynced = segment.isUnsynced()
     this.rank = segment.rank
+    this.isHidden = segment.isHidden
+    this.metadata = segment.metadata
     this.expectedDurationInMs = segment.expectedDurationInMs
     this.executedAtEpochTime = segment.getExecutedAtEpochTime()
     this.parts = segment.getParts().map((part) => new PartDto(part))


### PR DESCRIPTION
- Segments now exposes `isHidden`
- Segments now exposes a `metadata` field
- Sofie Server now loads all "hidden" Segments and Segments with no Parts and sends them to the frontend so the frontend can decide what to do with them.
  - Sofie Server now supports empty and hidden Segments when executing a Rundown (they are ignored in the execution and they are not possible to be Taken)