### PR TITLE
SOF-1791 Return correct type and format for Media.duration

### DIFF
--- a/src/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/src/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -155,10 +155,12 @@ export interface MongoMedia extends MongoId {
   mediaId: string
   mediainfo?: {
     format?: {
-      duration?: number
+      duration?: string
     }
   }
 }
+
+const MILLISECONDS: number = 1000
 
 export class MongoEntityConverter {
 
@@ -441,7 +443,7 @@ export class MongoEntityConverter {
     return {
       id: mongoMedia._id,
       sourceName: mongoMedia.mediaId,
-      duration: mongoMedia.mediainfo?.format?.duration ?? 0
+      duration: mongoMedia.mediainfo?.format?.duration ? Number.parseFloat(mongoMedia.mediainfo?.format?.duration) * MILLISECONDS : 0
     }
   }
 }

--- a/src/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/src/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -160,7 +160,7 @@ export interface MongoMedia extends MongoId {
   }
 }
 
-const MILLISECONDS: number = 1000
+const MILLISECONDS_TO_SECONDS_RATIO: number = 1000
 
 export class MongoEntityConverter {
 
@@ -443,7 +443,7 @@ export class MongoEntityConverter {
     return {
       id: mongoMedia._id,
       sourceName: mongoMedia.mediaId,
-      duration: mongoMedia.mediainfo?.format?.duration ? Number.parseFloat(mongoMedia.mediainfo?.format?.duration) * MILLISECONDS : 0
+      duration: mongoMedia.mediainfo?.format?.duration ? Number.parseFloat(mongoMedia.mediainfo?.format?.duration) * MILLISECONDS_TO_SECONDS_RATIO : 0
     }
   }
 }


### PR DESCRIPTION
The duration for Media is saved as a string in the database.

Media.duration is now an actual number and the value is in milliseconds when fetching it.