### PR TITLE
SOF-1783 No longer reset the NextCursor.part if the Part is also OnAir

### DIFF
--- a/src/model/entities/rundown.ts
+++ b/src/model/entities/rundown.ts
@@ -138,21 +138,22 @@ export class Rundown extends BasicRundown {
       const nextPart: Part = this.activeCursor.segment.findNextPart(this.activeCursor.part)
       const nextSegment: Segment | undefined = this.segments.find(segment => segment.id === nextPart.getSegmentId())
       this.nextCursor = this.createCursor(this.nextCursor, { segment: nextSegment, part: nextPart, owner })
+      this.markNextPart()
+      return
     } catch (exception) {
       if (!(exception instanceof LastPartInSegmentException)) {
         throw exception
       }
-      this.unmarkNextSegment()
-      // TODO: Refactor to use less nesting
-      try {
-        const segment: Segment = this.findNextValidSegment()
-        this.nextCursor = this.createCursor(this.nextCursor, { segment, part: segment.findFirstPart(), owner })
-        this.markNextSegment()
-      } catch (error) {
-        if (!(error instanceof LastSegmentInRundownException)) {
-          throw error
-        }
-        // TODO: Notify about last Segment.
+    }
+
+    this.unmarkNextSegment()
+    try {
+      const segment: Segment = this.findNextValidSegment()
+      this.nextCursor = this.createCursor(this.nextCursor, { segment, part: segment.findFirstPart(), owner })
+      this.markNextSegment()
+    } catch (error) {
+      if (!(error instanceof LastSegmentInRundownException)) {
+        throw error
       }
     }
 
@@ -479,7 +480,9 @@ export class Rundown extends BasicRundown {
       this.unmarkNextSegment()
     }
 
-    this.nextCursor?.part.reset()
+    if (this.activeCursor?.part.id !== this.nextCursor?.part.id) {
+      this.nextCursor?.part.reset()
+    }
     this.unmarkNextPart()
 
     this.nextCursor = this.createCursor(this.nextCursor, { segment: nextSegment, part: nextPart, owner: owner ?? Owner.SYSTEM })

--- a/src/model/entities/test/rundown.spec.ts
+++ b/src/model/entities/test/rundown.spec.ts
@@ -3215,6 +3215,41 @@ describe(Rundown.name, () => {
       verify(mockedNextPart.reset()).once()
     })
 
+    describe('nextCursor.Part is the same Part as the onAirCursor.Part OnAir', () => {
+      it('does not reset the OnAir Part', () => {
+        const mockedActivePart: Part = EntityMockFactory.createPartMock({ id: 'active-part-id', isOnAir: true })
+        const activePart: Part = instance(mockedActivePart)
+        const otherPartInActiveSegment: Part = EntityMockFactory.createPart({ id: 'other-part-in-active-segment-id' })
+        const mockedActiveSegment: Segment = EntityMockFactory.createSegmentMock({ id: 'active-segment-id', isOnAir: true, parts: [mockedActivePart, otherPartInActiveSegment] })
+        when(mockedActiveSegment.findPart(otherPartInActiveSegment.id)).thenReturn(otherPartInActiveSegment)
+        const activeSegment: Segment = instance(mockedActiveSegment)
+
+        const testee: Rundown = new Rundown({
+          isRundownActive: true,
+          alreadyActiveProperties: {
+            activeCursor: {
+              part: activePart,
+              segment: activeSegment,
+              owner: Owner.SYSTEM
+            },
+            nextCursor: {
+              part: activePart,
+              segment: activeSegment,
+              owner: Owner.SYSTEM
+            },
+            infinitePieces: new Map(),
+          },
+          segments: [
+            activeSegment
+          ],
+        } as RundownInterface)
+
+        testee.setNext(activeSegment.id, otherPartInActiveSegment.id)
+
+        verify(mockedActivePart.reset()).never()
+      })
+    })
+
     describe('when next part is on air', () => {
       it('throws an active part exception', () => {
         const activePart: Part = EntityMockFactory.createPart({ id: 'active-part-id', isOnAir: true })


### PR DESCRIPTION
When we reached the last Part of the last Segment, both the OnAirCursor and the NextCursor was pointing on the same Part.
This meant, that when we did `this.nextCursor.part.reset()` we also reset the OnAir Part removing the `timings` of the OnAir Part.
This caused an exception to happen when we tried to build the TimelineGroup for the Active Part.

We no longer reset the NextCursor.Part when doing a setNext if the OnAirCursor points to the same Part.

Also, did a slight refactoring to no longer have a try-catch nested within a try-catch.