### PR TITLE
SOF-1721 Make ids of VideoClipAsNextActions more unique

### DIFF
--- a/src/blueprints/tv2/action-factories/tv2-video-clip-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-video-clip-action-factory.ts
@@ -84,7 +84,7 @@ export class Tv2VideoClipActionFactory {
     const partId: string = 'videoClipInsertAction'
     const partInterface: PartInterface = this.createPartInterface(partId, videoClipData)
     return {
-      id: `videoClipAsNextAction_${videoClipData.fileName}`,
+      id: `videoClipAsNextAction_${videoClipData.name}_${videoClipData.fileName}`, // TODO: Utilize information about the Segment once we control ingest
       name: videoClipData.name,
       rundownId: videoClipData.rundownId,
       type: PartActionType.INSERT_PART_AS_NEXT,


### PR DESCRIPTION
If we had multiple VideoClip Actions for the same video file, all the VideoClipAsNextAction would get the same id, which is bad.
This makes the id's more unique by also including the Segment name in the id.
It's not ideal, but it's the best we got until we can generate the Actions during the Ingest flow.