### PR TITLE
SOF-1675 No longer Removing Next when inserting as OnAir.

### DIFF
--- a/src/business-logic/services/rundown-timeline-service.ts
+++ b/src/business-logic/services/rundown-timeline-service.ts
@@ -158,9 +158,9 @@ export class RundownTimelineService implements RundownService {
 
   private getEndStateForActivePart(rundown: Rundown): PartEndState {
     return this.blueprint.getEndStateForPart(
-      rundown.getActivePart(), 
-      rundown.getPreviousPart(), 
-      Date.now(), 
+      rundown.getActivePart(),
+      rundown.getPreviousPart(),
+      Date.now(),
       undefined
     )
   }
@@ -211,9 +211,15 @@ export class RundownTimelineService implements RundownService {
 
   public async insertPartAsOnAir(rundownId: string, part: Part): Promise<void> {
     const rundown: Rundown = await this.rundownRepository.getRundown(rundownId)
+    const unplannedNextPartToKeepAsNextPart: Part | undefined = !rundown.getNextPart().isPlanned ? rundown.getNextPart() : undefined
+
     rundown.insertPartAsNext(part)
     rundown.takeNext()
     rundown.getActivePart().setEndState(this.getEndStateForActivePart(rundown))
+
+    if (unplannedNextPartToKeepAsNextPart) {
+      rundown.insertPartAsNext(unplannedNextPartToKeepAsNextPart)
+    }
 
     await this.buildAndPersistTimeline(rundown)
 

--- a/src/model/entities/test/entity-test-factory.ts
+++ b/src/model/entities/test/entity-test-factory.ts
@@ -7,7 +7,7 @@ import { PieceLifespan } from '../../enums/piece-lifespan'
 export class EntityTestFactory {
   public static createRundown(rundownInterface: Partial<RundownInterface> = {}): Rundown {
     return new Rundown({
-      id: 'rundownId' + Math.floor(Math.random()*1000),
+      id: 'rundownId' + Math.floor(Math.random() * 1000),
       name: 'rundownName',
       segments: [],
       isRundownActive: false,
@@ -19,12 +19,11 @@ export class EntityTestFactory {
   public static createSegment(segmentInterface: Partial<SegmentInterface> = {}): Segment {
     return new Segment(
       {
-        id: 'segmentId' + Math.floor(Math.random()*1000),
+        id: 'segmentId' + Math.floor(Math.random() * 1000),
         rundownId: 'rundownId',
         name: 'segmentName',
         isNext: false,
         isOnAir: false,
-        rank: 666,
         parts: [],
         ...segmentInterface
       } as SegmentInterface)
@@ -32,12 +31,12 @@ export class EntityTestFactory {
 
   public static createPart(partInterface: Partial<PartInterface> = {}): Part {
     return new Part({
-      id: 'partId' + Math.floor(Math.random()*1000),
+      id: 'partId' + Math.floor(Math.random() * 1000),
       segmentId: 'segmentId',
-      rank: 666,
-      name: 'parrrrtName',
+      name: 'partName',
       isNext: false,
-      isOnAir:false,
+      isOnAir: false,
+      ingestedPart: {},
       pieces: [],
       ...partInterface
     } as PartInterface)
@@ -45,7 +44,7 @@ export class EntityTestFactory {
 
   public static createPiece(pieceInterface: Partial<PieceInterface> = {}): Piece {
     return new Piece({
-      id: 'pieceId' + Math.floor(Math.random()*1000),
+      id: 'pieceId' + Math.floor(Math.random() * 1000),
       partId: 'partId',
       name: 'pieceName',
       duration: 420,


### PR DESCRIPTION
Inserting a Part as on Air will now keep any already inserted Part as Next if there is one.

Also did some minor cleanup in the EntityTestFactory.