### PR TITLE
SOF-1796 Add ActionId to Parts

### DIFF
--- a/src/business-logic/services/execute-action-service.ts
+++ b/src/business-logic/services/execute-action-service.ts
@@ -174,6 +174,7 @@ export class ExecuteActionService implements ActionService {
 
   private createPartFromAction(partAction: PartAction): Part {
     const partInterface: PartInterface = partAction.data.partInterface
+    partInterface.metadata = { actionId: partAction.id }
     partInterface.id = this.makeUnique(partInterface.id)
 
     partInterface.pieces = partAction.data.pieceInterfaces.map(pieceInterface => new Piece({

--- a/src/business-logic/services/test/execute-action-service.spec.ts
+++ b/src/business-logic/services/test/execute-action-service.spec.ts
@@ -27,12 +27,12 @@ describe(ExecuteActionService.name, () => {
     describe('it receives an InsertPartAsOnAirAction', () => {
       it('calls RundownService.insertPartAsOnAir', async () => {
         const action: PartAction = createPartAction(PartActionType.INSERT_PART_AS_ON_AIR)
-        const rundownServiceMock: RundownService = mock<RundownService>()
+        const rundownService: RundownService = mock<RundownService>()
 
-        const testee: ExecuteActionService = createTestee({rundownService: rundownServiceMock}, {action})
+        const testee: ExecuteActionService = createTestee({ rundownService }, { action })
         await testee.executeAction(action.id, 'rundownId')
 
-        verify(rundownServiceMock.insertPartAsOnAir(anyString(), anyOfClass(Part))).once()
+        verify(rundownService.insertPartAsOnAir(anyString(), anyOfClass(Part))).once()
       })
 
       it('updates Part id to be unique', async () => {
@@ -48,6 +48,17 @@ describe(ExecuteActionService.name, () => {
         const [, lastExecutedPart] = capture(rundownServiceMock.insertPartAsOnAir).last()
 
         expect(firstExecutedPart.id).not.toBe(lastExecutedPart.id)
+      })
+
+      it('adds the ActionId to the metadata of the Part', async () => {
+        const action: PartAction = createPartAction(PartActionType.INSERT_PART_AS_ON_AIR)
+        const rundownService: RundownService = mock<RundownService>()
+
+        const testee: ExecuteActionService = createTestee({ rundownService }, { action })
+        await testee.executeAction(action.id, 'rundownId')
+
+        const [, part] = capture(rundownService.insertPartAsOnAir).last()
+        expect(part.metadata?.actionId).toBe(action.id)
       })
     })
 
@@ -75,6 +86,17 @@ describe(ExecuteActionService.name, () => {
         const [, lastExecutedPart] = capture(rundownServiceMock.insertPartAsNext).last()
 
         expect(firstExecutedPart.id).not.toBe(lastExecutedPart.id)
+      })
+
+      it('adds the ActionId to the metadata of the Part', async () => {
+        const action: PartAction = createPartAction(PartActionType.INSERT_PART_AS_NEXT)
+        const rundownService: RundownService = mock<RundownService>()
+
+        const testee: ExecuteActionService = createTestee({ rundownService }, { action })
+        await testee.executeAction(action.id, 'rundownId')
+
+        const [, part] = capture(rundownService.insertPartAsNext).last()
+        expect(part.metadata?.actionId).toBe(action.id)
       })
     })
 

--- a/src/model/entities/part.ts
+++ b/src/model/entities/part.ts
@@ -35,6 +35,12 @@ export interface PartInterface {
   endState?: PartEndState
 
   ingestedPart?: IngestedPart
+
+  metadata?: PartMetadata
+}
+
+export interface PartMetadata {
+  actionId?: string // If the Part was created from an Action, this is the id of said Action.
 }
 
 export class Part {
@@ -67,6 +73,8 @@ export class Part {
   private timings?: PartTimings
 
   private inTransition: InTransition
+
+  public metadata?: PartMetadata
 
   /*
    * The EndState of the Part
@@ -105,6 +113,8 @@ export class Part {
     this.isPartUnsynced = part.isUnsynced
 
     this.ingestedPart = part.ingestedPart
+
+    this.metadata = part.metadata
   }
 
   public putOnAir(): void {

--- a/src/presentation/dtos/part-dto.ts
+++ b/src/presentation/dtos/part-dto.ts
@@ -1,4 +1,4 @@
-import { Part } from '../../model/entities/part'
+import { Part, PartMetadata } from '../../model/entities/part'
 import { PieceDto } from './piece-dto'
 import { AutoNext } from '../../model/value-objects/auto-next'
 
@@ -16,6 +16,7 @@ export class PartDto {
   public readonly playedDuration: number
   public readonly autoNext?: AutoNext
   public readonly isPlanned: boolean
+  public readonly metadata?: PartMetadata
   public readonly pieces: PieceDto[]
 
   constructor(part: Part) {
@@ -32,6 +33,7 @@ export class PartDto {
     this.playedDuration = part.getPlayedDuration()
     this.autoNext = part.autoNext
     this.isPlanned = part.isPlanned
+    this.metadata = part.metadata
     this.pieces = part.getPieces().map((piece) => new PieceDto(piece))
   }
 }


### PR DESCRIPTION
Parts created from an Action now includes the ActionId on its metadata.

I decided to make an actually interface for `PartMetadata` instead of `unknown` since this is logic that SofieServer handles.