### PR TITLE
SOF-1812 Use filename as name for VideoClipAction pieces

### DIFF
--- a/src/blueprints/tv2/action-factories/tv2-video-clip-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-video-clip-action-factory.ts
@@ -119,7 +119,7 @@ export class Tv2VideoClipActionFactory {
     return {
       id: `videoClipActionPiece_${videoClipData.fileName}`,
       partId,
-      name: videoClipData.name,
+      name: videoClipData.fileName,
       layer: Tv2SourceLayer.VIDEO_CLIP,
       pieceLifespan: PieceLifespan.WITHIN_PART,
       transitionType: TransitionType.NO_TRANSITION,


### PR DESCRIPTION
Piece on VideoClipAction should use the filename of the VideoClip as Piece.name