### PR TITLE
SOF-1789 Introduce Validate blueprints configuration hook

### DIFF
--- a/src/blueprints/tv2/helpers/tv2-show-style-blueprint-configuration-mapper.ts
+++ b/src/blueprints/tv2/helpers/tv2-show-style-blueprint-configuration-mapper.ts
@@ -1,7 +1,8 @@
 import {
   Breaker,
   BreakerTransitionEffect,
-  GraphicsDefault, GraphicsSchema,
+  GraphicsDefault,
+  GraphicsSchema,
   GraphicsSetup,
   GraphicsTemplate,
   SplitScreenConfiguration,

--- a/src/blueprints/tv2/helpers/tv2-show-style-blueprint-configuration-mapper.ts
+++ b/src/blueprints/tv2/helpers/tv2-show-style-blueprint-configuration-mapper.ts
@@ -1,7 +1,7 @@
 import {
   Breaker,
   BreakerTransitionEffect,
-  GraphicsDefault,
+  GraphicsDefault, GraphicsSchema,
   GraphicsSetup,
   GraphicsTemplate,
   SplitScreenConfiguration,
@@ -15,6 +15,7 @@ interface CoreShowStyleBlueprintConfiguration {
   GfxDefaults: CoreGraphicsDefault[]
   GfxSetups: CoreGraphicsSetup[]
   GfxTemplates: CoreGraphicsTemplate[]
+  GfxSchemaTemplates: CoreGraphicsSchema[]
   DVEStyles: CoreSplitScreenConfiguration[]
   BreakerConfig: CoreBreaker[]
   Transitions: { _id: string, Transition: string }[]
@@ -38,6 +39,13 @@ interface CoreGraphicsSetup {
 interface CoreGraphicsTemplate {
   VizTemplate: string
   OutType?: string
+}
+
+interface CoreGraphicsSchema {
+  VizTemplate: string
+  INewsSkemaColumn: string
+  GfxSchemaTemplatesName: string
+  CasparCgDesignValues: string
 }
 
 interface CoreSplitScreenConfiguration {
@@ -69,6 +77,7 @@ export class Tv2ShowStyleBlueprintConfigurationMapper {
       graphicsDefault: this.mapGraphicsDefault(coreConfiguration.GfxDefaults),
       graphicsSetups: this.mapGraphicsSetups(coreConfiguration.GfxSetups),
       graphicsTemplates: this.mapGraphicsTemplates(coreConfiguration.GfxTemplates),
+      graphicsSchemas: this.mapGraphicsSchemas(coreConfiguration.GfxSchemaTemplates),
       selectedGraphicsSetup: this.findSelectedGraphicsSetup(coreConfiguration.GfxDefaults, coreConfiguration.GfxSetups),
       splitScreenConfigurations: this.mapSplitScreenConfigurations(coreConfiguration.DVEStyles),
       breakerTransitionEffectConfigurations: this.mapTransitionEffectConfigurations([
@@ -118,6 +127,17 @@ export class Tv2ShowStyleBlueprintConfigurationMapper {
       default:
         return PieceLifespan.WITHIN_PART
     }
+  }
+
+  private mapGraphicsSchemas(coreGraphicsSchemas: CoreGraphicsSchema[]): GraphicsSchema[] {
+    return coreGraphicsSchemas.map(schema => {
+      return {
+        iNewsName: schema.VizTemplate,
+        iNewsSchemaColumn: schema.INewsSkemaColumn,
+        graphicsTemplateName: schema.GfxSchemaTemplatesName,
+        casparCgDesignValues: schema.CasparCgDesignValues ? JSON.parse(schema.CasparCgDesignValues) : []
+      }
+    })
   }
 
   private findSelectedGraphicsSetup(coreGraphicsDefaults: CoreGraphicsDefault[], coreGraphicsSetups: CoreGraphicsSetup[]): GraphicsSetup {

--- a/src/blueprints/tv2/tv2-blueprint-configuration-validator.ts
+++ b/src/blueprints/tv2/tv2-blueprint-configuration-validator.ts
@@ -1,0 +1,43 @@
+import { Configuration } from '../../model/entities/configuration'
+import { StatusMessage } from '../../model/entities/status-message'
+import { BlueprintValidateConfiguration } from '../../model/value-objects/blueprint'
+import { Tv2ConfigurationMapper } from './helpers/tv2-configuration-mapper'
+import { Tv2BlueprintConfiguration } from './value-objects/tv2-blueprint-configuration'
+import { Tv2ShowStyleBlueprintConfiguration } from './value-objects/tv2-show-style-blueprint-configuration'
+import { StatusCode } from '../../model/enums/status-code'
+
+export class Tv2BlueprintConfigurationValidator implements BlueprintValidateConfiguration {
+
+  constructor(private readonly configurationMapper: Tv2ConfigurationMapper) {
+  }
+
+
+  public validateConfiguration(configuration: Configuration): StatusMessage[] {
+    const tv2BlueprintConfiguration: Tv2BlueprintConfiguration = this.configurationMapper.mapBlueprintConfiguration(configuration)
+    // Add validation as needed.
+    return [
+      ...this.validateShowStyleConfiguration(tv2BlueprintConfiguration.showStyle)
+    ]
+  }
+
+  private validateShowStyleConfiguration(showStyleConfiguration: Tv2ShowStyleBlueprintConfiguration): StatusMessage[] {
+    return [
+      ...this.validateGraphicsSchemas(showStyleConfiguration)
+    ]
+  }
+
+  private validateGraphicsSchemas(showStyleConfiguration: Tv2ShowStyleBlueprintConfiguration): StatusMessage[] {
+    return showStyleConfiguration.graphicsSchemas.flatMap(schema => {
+      return schema.casparCgDesignValues
+        .filter(designValues => designValues.name && designValues.name.includes(' '))
+        .map(designValues => {
+          return {
+            id: `${schema.iNewsName}_${schema.iNewsSchemaColumn}`,
+            title: 'Schema Configuration',
+            message: `The Schema ${schema.iNewsName} has an invalid CasparCgDesignValue. "${designValues.name}" contains a whitespace!`,
+            statusCode: StatusCode.BAD
+          }
+        })
+    })
+  }
+}

--- a/src/blueprints/tv2/tv2-blueprint-configuration-validator.ts
+++ b/src/blueprints/tv2/tv2-blueprint-configuration-validator.ts
@@ -8,8 +8,7 @@ import { StatusCode } from '../../model/enums/status-code'
 
 export class Tv2BlueprintConfigurationValidator implements BlueprintValidateConfiguration {
 
-  constructor(private readonly configurationMapper: Tv2ConfigurationMapper) {
-  }
+  constructor(private readonly configurationMapper: Tv2ConfigurationMapper) { }
 
 
   public validateConfiguration(configuration: Configuration): StatusMessage[] {
@@ -29,12 +28,12 @@ export class Tv2BlueprintConfigurationValidator implements BlueprintValidateConf
   private validateGraphicsSchemas(showStyleConfiguration: Tv2ShowStyleBlueprintConfiguration): StatusMessage[] {
     return showStyleConfiguration.graphicsSchemas.flatMap(schema => {
       return schema.casparCgDesignValues
-        .filter(designValues => designValues.name && designValues.name.includes(' '))
-        .map(designValues => {
+        .filter(designValues => designValues.name?.includes(' '))
+        .map(designValue => {
           return {
             id: `${schema.iNewsName}_${schema.iNewsSchemaColumn}`,
             title: `${schema.iNewsName} Schema Configuration`,
-            message: `The Schema ${schema.iNewsName} has an invalid CasparCgDesignValue. "${designValues.name}" contains a whitespace!`,
+            message: `The Schema ${schema.iNewsName} has an invalid CasparCg design value, since the design name '${designValue.name}' must not contain whitespace`,
             statusCode: StatusCode.BAD
           }
         })

--- a/src/blueprints/tv2/tv2-blueprint-configuration-validator.ts
+++ b/src/blueprints/tv2/tv2-blueprint-configuration-validator.ts
@@ -33,7 +33,7 @@ export class Tv2BlueprintConfigurationValidator implements BlueprintValidateConf
         .map(designValues => {
           return {
             id: `${schema.iNewsName}_${schema.iNewsSchemaColumn}`,
-            title: 'Schema Configuration',
+            title: `${schema.iNewsName} Schema Configuration`,
             message: `The Schema ${schema.iNewsName} has an invalid CasparCgDesignValue. "${designValues.name}" contains a whitespace!`,
             statusCode: StatusCode.BAD
           }

--- a/src/blueprints/tv2/tv2-blueprint.ts
+++ b/src/blueprints/tv2/tv2-blueprint.ts
@@ -2,7 +2,7 @@ import {
   Blueprint,
   BlueprintGenerateActions,
   BlueprintGetEndStateForPart,
-  BlueprintOnTimelineGenerate
+  BlueprintOnTimelineGenerate, BlueprintValidateConfiguration
 } from '../../model/value-objects/blueprint'
 import { RundownPersistentState } from '../../model/value-objects/rundown-persistent-state'
 import { Part } from '../../model/entities/part'
@@ -11,12 +11,14 @@ import { Timeline } from '../../model/entities/timeline'
 import { Configuration } from '../../model/entities/configuration'
 import { Action, ActionManifest, MutateActionMethods } from '../../model/entities/action'
 import { Tv2Action } from './value-objects/tv2-action'
+import { StatusMessage } from '../../model/entities/status-message'
 
 export class Tv2Blueprint implements Blueprint {
   constructor(
     private readonly endStateForPartService: BlueprintGetEndStateForPart,
     private readonly onTimelineGenerateService: BlueprintOnTimelineGenerate,
-    private readonly actionsService: BlueprintGenerateActions
+    private readonly actionsService: BlueprintGenerateActions,
+    private readonly configurationValidator: BlueprintValidateConfiguration
   ) {}
 
   public getEndStateForPart(
@@ -56,5 +58,9 @@ export class Tv2Blueprint implements Blueprint {
       return []
     }
     return this.actionsService.getMutateActionMethods(action)
+  }
+
+  public validateConfiguration(configuration: Configuration): StatusMessage[] {
+    return this.configurationValidator.validateConfiguration(configuration)
   }
 }

--- a/src/blueprints/tv2/tv2-blueprints-facade.ts
+++ b/src/blueprints/tv2/tv2-blueprints-facade.ts
@@ -47,6 +47,7 @@ import { Tv2RobotTimelineObjectFactory } from './timeline-object-factories/inter
 import {
   Tv2TelemetricsTimelineObjectFactory
 } from './timeline-object-factories/tv2-telemetrics-timeline-object-factory'
+import { Tv2BlueprintConfigurationValidator } from './tv2-blueprint-configuration-validator'
 
 export class Tv2BlueprintsFacade {
   public static createBlueprint(): Blueprint {
@@ -109,7 +110,8 @@ export class Tv2BlueprintsFacade {
     return new Tv2Blueprint(
       new Tv2EndStateForPartService(sisyfosPersistentLayerFinder),
       new Tv2OnTimelineGenerateService(configurationMapper, sisyfosPersistentLayerFinder),
-      actionService
+      actionService,
+      new Tv2BlueprintConfigurationValidator(configurationMapper)
     )
   }
 }

--- a/src/blueprints/tv2/value-objects/tv2-show-style-blueprint-configuration.ts
+++ b/src/blueprints/tv2/value-objects/tv2-show-style-blueprint-configuration.ts
@@ -4,6 +4,7 @@ export interface Tv2ShowStyleBlueprintConfiguration {
   graphicsDefault: GraphicsDefault
   graphicsSetups: GraphicsSetup[]
   graphicsTemplates: GraphicsTemplate[]
+  graphicsSchemas: GraphicsSchema[]
   selectedGraphicsSetup: GraphicsSetup
   splitScreenConfigurations: SplitScreenConfiguration[]
   breakerTransitionEffectConfigurations: BreakerTransitionEffect[]
@@ -27,6 +28,19 @@ export interface GraphicsSetup {
 export interface GraphicsTemplate {
   name: string
   lifespan: PieceLifespan
+}
+
+export interface GraphicsSchema {
+  iNewsName: string
+  iNewsSchemaColumn: string
+  graphicsTemplateName: string
+  casparCgDesignValues: CasparCgDesignValue[]
+}
+
+export interface CasparCgDesignValue {
+  name: string
+  properties: string[]
+  backgroundLoop: string
 }
 
 export interface SplitScreenConfiguration {

--- a/src/business-logic/facades/service-facade.ts
+++ b/src/business-logic/facades/service-facade.ts
@@ -123,7 +123,8 @@ export class ServiceFacade {
       BlueprintsFacade.createBlueprint(),
       ServiceFacade.createStatusMessageService(),
       RepositoryFacade.createConfigurationRepository(),
-      RepositoryFacade.createShowStyleChangedListener()
+      RepositoryFacade.createShowStyleChangedListener(),
+      LoggerFacade.createLogger()
     )
   }
 

--- a/src/business-logic/facades/service-facade.ts
+++ b/src/business-logic/facades/service-facade.ts
@@ -9,8 +9,8 @@ import { BlueprintsFacade } from '../../blueprints/blueprints-facade'
 import { ActionService } from '../services/interfaces/action-service'
 import { ExecuteActionService } from '../services/execute-action-service'
 import { EventEmitterFacade } from '../../presentation/facades/event-emitter-facade'
-import { DatabaseChangeService } from '../services/interfaces/database-change-service'
-import { IngestDatabaseChangeService } from '../services/ingest-database-change-service'
+import { DataChangeService } from '../services/interfaces/data-change-service'
+import { IngestDataChangedService } from '../services/ingest-data-changed-service'
 import { BlueprintTimelineBuilder } from '../services/blueprint-timeline-builder'
 import { IngestService } from '../services/interfaces/ingest-service'
 import { Tv2INewsIngestService } from '../services/tv2-inews-ingest-service'
@@ -20,10 +20,13 @@ import { IngestedEntityToEntityMapper } from '../services/ingested-entity-to-ent
 import { ActionTriggerService } from '../services/interfaces/action-trigger-service'
 import { ActionTriggerServiceImplementation } from '../services/action-trigger-service-implementation'
 import { LoggerFacade } from '../../logger/logger-facade'
-import { MediaDatabaseChangeService } from '../services/media-database-change-service'
+import { MediaDatabaseChangedService } from '../services/media-database-changed-service'
 import { ConfigurationService } from '../services/interfaces/configuration-service'
 import { ConfigurationServiceImplementation } from '../services/configuration-service-implementation'
 import { DeviceChangedService } from '../services/device-changed-service'
+import { ConfigurationChangedService } from '../services/configuration-changed-service'
+import { StatusMessageService } from '../services/interfaces/status-message-service'
+import { StatusMessageServiceImplementation } from '../services/status-message-service-implementation'
 
 export class ServiceFacade {
   public static createRundownService(): RundownService {
@@ -69,8 +72,8 @@ export class ServiceFacade {
     )
   }
 
-  public static createIngestChangeService(): DatabaseChangeService {
-    return IngestDatabaseChangeService.getInstance(
+  public static createIngestChangeService(): DataChangeService {
+    return IngestDataChangedService.getInstance(
       RepositoryFacade.createIngestedRundownRepository(),
       RepositoryFacade.createRundownRepository(),
       RepositoryFacade.createSegmentRepository(),
@@ -87,8 +90,8 @@ export class ServiceFacade {
     )
   }
 
-  public static createMediaDataChangeService(): DatabaseChangeService {
-    return MediaDatabaseChangeService.getInstance(
+  public static createMediaDataChangeService(): DataChangeService {
+    return MediaDatabaseChangedService.getInstance(
       EventEmitterFacade.createMediaEventEmitter(),
       RepositoryFacade.createMediaChangedListener()
     )
@@ -106,13 +109,28 @@ export class ServiceFacade {
     )
   }
 
-  public static createDeviceDataChangedService(): DatabaseChangeService {
+  public static createDeviceDataChangedService(): DataChangeService {
     return DeviceChangedService.getInstance(
-      EventEmitterFacade.createStatusMessageEventEmitter(),
-      RepositoryFacade.createStatusMessageRepository(),
+      ServiceFacade.createStatusMessageService(),
       RepositoryFacade.createDeviceRepository(),
       RepositoryFacade.createDeviceDataChangedListener(),
       LoggerFacade.createLogger()
+    )
+  }
+
+  public static createConfigurationDataChangedService(): DataChangeService {
+    return ConfigurationChangedService.getInstance(
+      BlueprintsFacade.createBlueprint(),
+      ServiceFacade.createStatusMessageService(),
+      RepositoryFacade.createConfigurationRepository(),
+      RepositoryFacade.createShowStyleChangedListener()
+    )
+  }
+
+  public static createStatusMessageService(): StatusMessageService {
+    return new StatusMessageServiceImplementation(
+      EventEmitterFacade.createStatusMessageEventEmitter(),
+      RepositoryFacade.createStatusMessageRepository()
     )
   }
 }

--- a/src/business-logic/services/configuration-changed-service.ts
+++ b/src/business-logic/services/configuration-changed-service.ts
@@ -43,21 +43,8 @@ export class ConfigurationChangedService implements DataChangeService {
     logger: Logger
   ) {
     this.logger = logger.tag(ConfigurationChangedService.name)
-    this.callAgainOnError(() => this.validateConfiguration())
+    this.validateConfiguration().catch(error => this.logger.data(error).error('Unable to validate configuration'))
     this.listenForShowStyleChanges(showStyleConfigurationChangedListener)
-  }
-
-  private callAgainOnError(callback: () => Promise<void>, attemptNumber: number = 1): void {
-    const maxAttempts: number = 10
-    callback().catch((error) => {
-      if (attemptNumber >= maxAttempts){
-        this.logger.data(error).error(`The retry limit of ${maxAttempts} is reached for calling the provided function`)
-        return
-      }
-      setTimeout(() => {
-        this.callAgainOnError(callback, ++attemptNumber)
-      }, 1000)
-    })
   }
 
   private listenForShowStyleChanges(showStyleConfigurationChangedListener: DataChangedListener<ShowStyle>): void {

--- a/src/business-logic/services/configuration-changed-service.ts
+++ b/src/business-logic/services/configuration-changed-service.ts
@@ -1,0 +1,54 @@
+import { DataChangeService } from './interfaces/data-change-service'
+import { DataChangedListener } from '../../data-access/repositories/interfaces/data-changed-listener'
+import { ShowStyle } from '../../model/entities/show-style'
+import { Blueprint } from '../../model/value-objects/blueprint'
+import { StatusMessage } from '../../model/entities/status-message'
+import { ConfigurationRepository } from '../../data-access/repositories/interfaces/configuration-repository'
+import { Configuration } from '../../model/entities/configuration'
+import { StatusMessageService } from './interfaces/status-message-service'
+
+const CONFIGURATION_STATUS_MESSAGE_ID_PREFIX: string = 'INVALID_CONFIGURATION_'
+
+export class ConfigurationChangedService implements DataChangeService {
+
+  private static instance: DataChangeService
+
+  public static getInstance(
+    blueprint: Blueprint,
+    statusMessageService: StatusMessageService,
+    configurationRepository: ConfigurationRepository,
+    showStyleConfigurationChangedListener: DataChangedListener<ShowStyle>
+  ): DataChangeService {
+    if (!this.instance) {
+      this.instance = new ConfigurationChangedService(blueprint, statusMessageService, configurationRepository, showStyleConfigurationChangedListener)
+    }
+    return this.instance
+  }
+
+  private constructor(
+    private readonly blueprint: Blueprint,
+    private readonly statusMessageService: StatusMessageService,
+    private readonly configurationRepository: ConfigurationRepository,
+    showStyleConfigurationChangedListener: DataChangedListener<ShowStyle>
+  ) {
+    this.listenForShowStyleChanges(showStyleConfigurationChangedListener)
+  }
+
+  private listenForShowStyleChanges(showStyleConfigurationChangedListener: DataChangedListener<ShowStyle>): void {
+    showStyleConfigurationChangedListener.onUpdated(() => void this.validateConfiguration())
+  }
+
+  private async validateConfiguration(): Promise<void> {
+    this.configurationRepository.clearConfigurationCache()
+    const configuration: Configuration = await this.configurationRepository.getConfiguration()
+    const statusMessages: StatusMessage[] = this.blueprint.validateConfiguration(configuration).map(statusMessage => {
+      return {
+        ...statusMessage,
+        id: `${CONFIGURATION_STATUS_MESSAGE_ID_PREFIX}${statusMessage.id}` // We need to prefix the id, so we can differentiate the configuration status messages from other status messages.
+      }
+    })
+
+    await this.statusMessageService.updateStatusMessages(statusMessages)
+    await this.statusMessageService.deleteStatusMessagesWithIdPrefixNotInCollection(CONFIGURATION_STATUS_MESSAGE_ID_PREFIX, statusMessages)
+  }
+}

--- a/src/business-logic/services/configuration-changed-service.ts
+++ b/src/business-logic/services/configuration-changed-service.ts
@@ -51,8 +51,7 @@ export class ConfigurationChangedService implements DataChangeService {
     const maxAttempts: number = 10
     callback().catch((error) => {
       if (attemptNumber >= maxAttempts){
-        this.logger.debug(`Unable to successfully call method on ${attemptNumber} attempts. Stopping recursive function`)
-        this.logger.error(error)
+        this.logger.data(error).error(`The retry limit of ${maxAttempts} is reached for calling the provided function`)
         return
       }
       setTimeout(() => {

--- a/src/business-logic/services/configuration-changed-service.ts
+++ b/src/business-logic/services/configuration-changed-service.ts
@@ -43,12 +43,14 @@ export class ConfigurationChangedService implements DataChangeService {
     logger: Logger
   ) {
     this.logger = logger.tag(ConfigurationChangedService.name)
-    this.validateConfiguration().catch(error => this.logger.data(error).error('Unable to validate configuration'))
+    this.validateConfiguration().catch(error => this.logger.data(error).error('Failed to validate configuration'))
     this.listenForShowStyleChanges(showStyleConfigurationChangedListener)
   }
 
   private listenForShowStyleChanges(showStyleConfigurationChangedListener: DataChangedListener<ShowStyle>): void {
-    showStyleConfigurationChangedListener.onUpdated(() => void this.validateConfiguration())
+    showStyleConfigurationChangedListener.onUpdated(() => {
+      this.validateConfiguration().catch(error => this.logger.data(error).error('Failed to validate configuration'))
+    })
   }
 
   private async validateConfiguration(): Promise<void> {

--- a/src/business-logic/services/device-changed-service.ts
+++ b/src/business-logic/services/device-changed-service.ts
@@ -39,22 +39,9 @@ export class DeviceChangedService implements DataChangeService {
     logger: Logger
   ) {
     this.logger = logger.tag(DeviceChangedService.name)
-    this.callAgainOnError(() => this.updateStatusMessageFromCurrentDeviceStatus())
+    this.updateStatusMessageFromCurrentDeviceStatus()
+      .catch((error) => this.logger.data(error).error('Unable to update status messages from current devices'))
     this.listenForStatusMessageChanges(deviceChangedListener)
-  }
-
-  private callAgainOnError(callback: () => Promise<void>, attemptNumber: number = 1): void {
-    const maxAttempts: number = 10
-    callback().catch((error) => {
-      if (attemptNumber >= maxAttempts){
-        this.logger.debug(`Unable to successfully call method on ${attemptNumber} attempts. Stopping recursive function`)
-        this.logger.error(error)
-        return
-      }
-      setTimeout(() => {
-        this.callAgainOnError(callback, ++attemptNumber)
-      }, 1000)
-    })
   }
 
   private async updateStatusMessageFromCurrentDeviceStatus(): Promise<void> {

--- a/src/business-logic/services/device-changed-service.ts
+++ b/src/business-logic/services/device-changed-service.ts
@@ -1,31 +1,27 @@
-import { DatabaseChangeService } from './interfaces/database-change-service'
-import { StatusMessageEventEmitter } from './interfaces/status-message-event-emitter'
+import { DataChangeService } from './interfaces/data-change-service'
 import { DataChangedListener } from '../../data-access/repositories/interfaces/data-changed-listener'
 import { Device } from '../../model/entities/device'
 import { StatusMessage } from '../../model/entities/status-message'
-import { StatusMessageRepository } from '../../data-access/repositories/interfaces/status-message-repository'
-import { NotFoundException } from '../../model/exceptions/not-found-exception'
 import { StatusCode } from '../../model/enums/status-code'
 import { DeviceRepository } from '../../data-access/repositories/interfaces/device-repository'
 import { Logger } from '../../logger/logger'
+import { StatusMessageService } from './interfaces/status-message-service'
 
 // TODO: Find a way to translate
 const NOT_CONNECTED_MESSAGE: string = 'Not connected'
 
-export class DeviceChangedService implements DatabaseChangeService {
-  private static instance: DatabaseChangeService
+export class DeviceChangedService implements DataChangeService {
+  private static instance: DataChangeService
 
   public static getInstance(
-    statusMessageEventEmitter: StatusMessageEventEmitter,
-    statusMessageRepository: StatusMessageRepository,
+    statusMessageService: StatusMessageService,
     deviceRepository: DeviceRepository,
     deviceChangedListener: DataChangedListener<Device>,
     logger: Logger
-  ): DatabaseChangeService {
+  ): DataChangeService {
     if (!this.instance) {
       this.instance = new DeviceChangedService(
-        statusMessageEventEmitter,
-        statusMessageRepository,
+        statusMessageService,
         deviceRepository,
         deviceChangedListener,
         logger
@@ -37,8 +33,7 @@ export class DeviceChangedService implements DatabaseChangeService {
   private readonly logger: Logger
 
   constructor(
-    private readonly statusMessageEventEmitter: StatusMessageEventEmitter,
-    private readonly statusMessageRepository: StatusMessageRepository,
+    private readonly statusMessageService: StatusMessageService,
     private readonly deviceRepository: DeviceRepository,
     deviceChangedListener: DataChangedListener<Device>,
     logger: Logger
@@ -78,49 +73,7 @@ export class DeviceChangedService implements DatabaseChangeService {
       device.statusMessage = NOT_CONNECTED_MESSAGE
     }
 
-    const statusMessageFromDatabase: StatusMessage | undefined = await this.getStatusMessageFromDatabase(device.id)
-    if (!statusMessageFromDatabase) {
-      await this.createNewStatusMessageIfStatusIsNotGood(device)
-      return
-    }
-
-    if (!this.isStatusMessagesDifferent(statusMessageFromDatabase, this.convertDeviceToStatusMessage(device))) {
-      return
-    }
-
-    this.statusMessageEventEmitter.emitStatusMessageEvent(this.convertDeviceToStatusMessage(device))
-
-    if ([StatusCode.GOOD].includes(device.statusCode)) {
-      await this.statusMessageRepository.deleteStatusMessage(statusMessageFromDatabase.id)
-      return
-    }
-
-    await this.statusMessageRepository.updateStatusMessage(this.convertDeviceToStatusMessage(device))
-  }
-
-  private async createNewStatusMessageIfStatusIsNotGood(device: Device): Promise<void> {
-    if ([StatusCode.GOOD].includes(device.statusCode)) {
-      return
-    }
-    this.statusMessageEventEmitter.emitStatusMessageEvent(this.convertDeviceToStatusMessage(device))
-    await this.statusMessageRepository.createStatusMessage(this.convertDeviceToStatusMessage(device))
-  }
-
-  private async getStatusMessageFromDatabase(statusMessageId: string): Promise<StatusMessage | undefined> {
-    try {
-      return await this.statusMessageRepository.getStatusMessage(statusMessageId)
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        return
-      }
-      throw error
-    }
-  }
-
-  private isStatusMessagesDifferent(statusMessageOne: StatusMessage, statusMessageTwo: StatusMessage): boolean {
-    const isDifferentStatusCode: boolean = statusMessageOne.statusCode != statusMessageTwo.statusCode
-    const isDifferentMessage: boolean = statusMessageOne.message != statusMessageTwo.message
-    return isDifferentStatusCode || isDifferentMessage
+    await this.statusMessageService.updateStatusMessage(this.convertDeviceToStatusMessage(device))
   }
 
   private convertDeviceToStatusMessage(device: Device): StatusMessage {

--- a/src/business-logic/services/ingest-data-changed-service.ts
+++ b/src/business-logic/services/ingest-data-changed-service.ts
@@ -1,4 +1,4 @@
-import { DatabaseChangeService } from './interfaces/database-change-service'
+import { DataChangeService } from './interfaces/data-change-service'
 import { RundownRepository } from '../../data-access/repositories/interfaces/rundown-repository'
 import { Rundown } from '../../model/entities/rundown'
 import { DataChangedListener } from '../../data-access/repositories/interfaces/data-changed-listener'
@@ -22,9 +22,9 @@ import { PieceRepository } from '../../data-access/repositories/interfaces/piece
 
 const BULK_EXECUTION_TIMESPAN_IN_MS: number = 500
 
-export class IngestDatabaseChangeService implements DatabaseChangeService {
+export class IngestDataChangedService implements DataChangeService {
 
-  private static instance: DatabaseChangeService
+  private static instance: DataChangeService
 
   public static getInstance(
     ingestedRundownRepository: IngestedRundownRepository,
@@ -40,9 +40,9 @@ export class IngestDatabaseChangeService implements DatabaseChangeService {
     rundownChangeListener: DataChangedListener<IngestedRundown>,
     segmentChangedListener: DataChangedListener<IngestedSegment>,
     partChangedListener: DataChangedListener<IngestedPart>,
-  ): DatabaseChangeService {
+  ): DataChangeService {
     if (!this.instance) {
-      this.instance = new IngestDatabaseChangeService(
+      this.instance = new IngestDataChangedService(
         ingestedRundownRepository,
         rundownRepository,
         segmentRepository,
@@ -85,7 +85,7 @@ export class IngestDatabaseChangeService implements DatabaseChangeService {
     segmentChangedListener: DataChangedListener<IngestedSegment>,
     partChangedListener: DataChangedListener<IngestedPart>,
   ) {
-    this.logger = logger.tag(IngestDatabaseChangeService.name)
+    this.logger = logger.tag(IngestDataChangedService.name)
 
     this.listenForRundownChanges(rundownChangeListener)
     this.listenForSegmentChanges(segmentChangedListener)

--- a/src/business-logic/services/interfaces/data-change-service.ts
+++ b/src/business-logic/services/interfaces/data-change-service.ts
@@ -1,0 +1,1 @@
+export interface DataChangeService {}

--- a/src/business-logic/services/interfaces/database-change-service.ts
+++ b/src/business-logic/services/interfaces/database-change-service.ts
@@ -1,1 +1,0 @@
-export interface DatabaseChangeService {}

--- a/src/business-logic/services/interfaces/status-message-service.ts
+++ b/src/business-logic/services/interfaces/status-message-service.ts
@@ -3,5 +3,5 @@ import { StatusMessage } from '../../../model/entities/status-message'
 export interface StatusMessageService {
   updateStatusMessage(statusMessage: StatusMessage): Promise<void>
   updateStatusMessages(statusMessage: StatusMessage[]): Promise<void>
-  deleteStatusMessagesWithIdPrefixNotInCollection(idPrefix: string, statusMessagesNotToDelete: StatusMessage[]): Promise<void>
+  deleteStatusMessagesWithIdPrefixNotInCollection(idPrefix: string, statusMessagesToKeep: StatusMessage[]): Promise<void>
 }

--- a/src/business-logic/services/interfaces/status-message-service.ts
+++ b/src/business-logic/services/interfaces/status-message-service.ts
@@ -1,0 +1,7 @@
+import { StatusMessage } from '../../../model/entities/status-message'
+
+export interface StatusMessageService {
+  updateStatusMessage(statusMessage: StatusMessage): Promise<void>
+  updateStatusMessages(statusMessage: StatusMessage[]): Promise<void>
+  deleteStatusMessagesWithIdPrefixNotInCollection(idPrefix: string, statusMessagesNotToDelete: StatusMessage[]): Promise<void>
+}

--- a/src/business-logic/services/media-database-changed-service.ts
+++ b/src/business-logic/services/media-database-changed-service.ts
@@ -1,18 +1,18 @@
-import { DatabaseChangeService } from './interfaces/database-change-service'
+import { DataChangeService } from './interfaces/data-change-service'
 import { MediaEventEmitter } from './interfaces/media-event-emitter'
 import { DataChangedListener } from '../../data-access/repositories/interfaces/data-changed-listener'
 import { Media } from '../../model/entities/media'
 
-export class MediaDatabaseChangeService implements DatabaseChangeService {
+export class MediaDatabaseChangedService implements DataChangeService {
 
-  private static instance: DatabaseChangeService
+  private static instance: DataChangeService
 
   public static getInstance(
     mediaEventEmitter: MediaEventEmitter,
     mediaChangedListener: DataChangedListener<Media>
-  ): DatabaseChangeService {
+  ): DataChangeService {
     if (!this.instance) {
-      this.instance = new MediaDatabaseChangeService(
+      this.instance = new MediaDatabaseChangedService(
         mediaEventEmitter,
         mediaChangedListener
       )

--- a/src/business-logic/services/status-message-service-implementation.ts
+++ b/src/business-logic/services/status-message-service-implementation.ts
@@ -48,7 +48,8 @@ export class StatusMessageServiceImplementation implements StatusMessageService 
 
   private async getStatusMessageFromDatabase(statusMessageId: string): Promise<StatusMessage | undefined> {
     try {
-      return this.statusMessageRepository.getStatusMessage(statusMessageId)
+      // We must await here. If we don't, then the try-catch does nothing resulting in wrong behaviour.
+      return await this.statusMessageRepository.getStatusMessage(statusMessageId)
     } catch (error) {
       if (error instanceof NotFoundException) {
         return

--- a/src/business-logic/services/status-message-service-implementation.ts
+++ b/src/business-logic/services/status-message-service-implementation.ts
@@ -48,7 +48,7 @@ export class StatusMessageServiceImplementation implements StatusMessageService 
 
   private async getStatusMessageFromDatabase(statusMessageId: string): Promise<StatusMessage | undefined> {
     try {
-      return await this.statusMessageRepository.getStatusMessage(statusMessageId)
+      return this.statusMessageRepository.getStatusMessage(statusMessageId)
     } catch (error) {
       if (error instanceof NotFoundException) {
         return
@@ -63,8 +63,8 @@ export class StatusMessageServiceImplementation implements StatusMessageService 
     return isDifferentStatusCode || isDifferentMessage
   }
 
-  public async deleteStatusMessagesWithIdPrefixNotInCollection(idPrefix: string, statusMessagesNotToDelete: StatusMessage[]): Promise<void> {
-    const statusMessageIdsNotToBeDeleted: string[] = statusMessagesNotToDelete.map(statusMessage => statusMessage.id)
+  public async deleteStatusMessagesWithIdPrefixNotInCollection(idPrefix: string, statusMessagesToKeep: StatusMessage[]): Promise<void> {
+    const statusMessageIdsNotToBeDeleted: string[] = statusMessagesToKeep.map(statusMessage => statusMessage.id)
     const statusMessages: StatusMessage[] = await this.statusMessageRepository.getStatusMessagesWithIdPrefix(idPrefix)
 
     await Promise.all(statusMessages.filter(statusMessage => !statusMessageIdsNotToBeDeleted.includes(statusMessage.id))

--- a/src/business-logic/services/status-message-service-implementation.ts
+++ b/src/business-logic/services/status-message-service-implementation.ts
@@ -1,0 +1,78 @@
+import { StatusMessage } from '../../model/entities/status-message'
+import { StatusMessageService } from './interfaces/status-message-service'
+import { StatusMessageEventEmitter } from './interfaces/status-message-event-emitter'
+import { StatusMessageRepository } from '../../data-access/repositories/interfaces/status-message-repository'
+import { StatusCode } from '../../model/enums/status-code'
+import { NotFoundException } from '../../model/exceptions/not-found-exception'
+
+export class StatusMessageServiceImplementation implements StatusMessageService {
+
+  constructor(
+    private readonly statusMessageEventEmitter: StatusMessageEventEmitter,
+    private readonly statusMessageRepository: StatusMessageRepository
+  ) { }
+
+  public async updateStatusMessages(statusMessage: StatusMessage[]): Promise<void> {
+    await Promise.all(
+      statusMessage.map(statusMessage => this.updateStatusMessage(statusMessage))
+    )
+  }
+
+  public async updateStatusMessage(statusMessage: StatusMessage): Promise<void> {
+    const statusMessageFromDatabase: StatusMessage | undefined = await this.getStatusMessageFromDatabase(statusMessage.id)
+    if (!statusMessageFromDatabase) {
+      return this.createNewStatusMessageIfStatusIsNotGood(statusMessage)
+    }
+
+    if (!this.isStatusMessagesDifferent(statusMessage, statusMessageFromDatabase)) {
+      return
+    }
+
+    this.statusMessageEventEmitter.emitStatusMessageEvent(statusMessage)
+
+    if ([StatusCode.GOOD].includes(statusMessage.statusCode)) {
+      await this.statusMessageRepository.deleteStatusMessage(statusMessage.id)
+      return
+    }
+
+    await this.statusMessageRepository.updateStatusMessage(statusMessage)
+  }
+
+  private async createNewStatusMessageIfStatusIsNotGood(statusMessage: StatusMessage): Promise<void> {
+    if ([StatusCode.GOOD].includes(statusMessage.statusCode)) {
+      return
+    }
+    this.statusMessageEventEmitter.emitStatusMessageEvent(statusMessage)
+    await this.statusMessageRepository.createStatusMessage(statusMessage)
+  }
+
+  private async getStatusMessageFromDatabase(statusMessageId: string): Promise<StatusMessage | undefined> {
+    try {
+      return await this.statusMessageRepository.getStatusMessage(statusMessageId)
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        return
+      }
+      throw error
+    }
+  }
+
+  private isStatusMessagesDifferent(statusMessageOne: StatusMessage, statusMessageTwo: StatusMessage): boolean {
+    const isDifferentStatusCode: boolean = statusMessageOne.statusCode != statusMessageTwo.statusCode
+    const isDifferentMessage: boolean = statusMessageOne.message != statusMessageTwo.message
+    return isDifferentStatusCode || isDifferentMessage
+  }
+
+  public async deleteStatusMessagesWithIdPrefixNotInCollection(idPrefix: string, statusMessagesNotToDelete: StatusMessage[]): Promise<void> {
+    const statusMessageIdsNotToBeDeleted: string[] = statusMessagesNotToDelete.map(statusMessage => statusMessage.id)
+    const statusMessages: StatusMessage[] = await this.statusMessageRepository.getStatusMessagesWithIdPrefix(idPrefix)
+
+    await Promise.all(statusMessages.filter(statusMessage => !statusMessageIdsNotToBeDeleted.includes(statusMessage.id))
+      .map(async statusMessage => {
+        statusMessage.statusCode = StatusCode.GOOD
+        statusMessage.message = ''
+        this.statusMessageEventEmitter.emitStatusMessageEvent(statusMessage)
+        await this.statusMessageRepository.deleteStatusMessage(statusMessage.id)
+      }))
+  }
+}

--- a/src/business-logic/services/status-message-service-implementation.ts
+++ b/src/business-logic/services/status-message-service-implementation.ts
@@ -59,8 +59,8 @@ export class StatusMessageServiceImplementation implements StatusMessageService 
   }
 
   private isStatusMessagesDifferent(statusMessageOne: StatusMessage, statusMessageTwo: StatusMessage): boolean {
-    const isDifferentStatusCode: boolean = statusMessageOne.statusCode != statusMessageTwo.statusCode
-    const isDifferentMessage: boolean = statusMessageOne.message != statusMessageTwo.message
+    const isDifferentStatusCode: boolean = statusMessageOne.statusCode !== statusMessageTwo.statusCode
+    const isDifferentMessage: boolean = statusMessageOne.message !== statusMessageTwo.message
     return isDifferentStatusCode || isDifferentMessage
   }
 

--- a/src/business-logic/services/test/device-changed-service.spec.ts
+++ b/src/business-logic/services/test/device-changed-service.spec.ts
@@ -1,283 +1,117 @@
 import { DeviceChangedService } from '../device-changed-service'
-import { anything, capture, instance, mock, verify, when } from '@typestrong/ts-mockito'
-import { StatusMessageEventEmitter } from '../interfaces/status-message-event-emitter'
-import { StatusMessageRepository } from '../../../data-access/repositories/interfaces/status-message-repository'
+import { anything, capture, instance, mock, when } from '@typestrong/ts-mockito'
 import { DataChangedListener } from '../../../data-access/repositories/interfaces/data-changed-listener'
 import { Device } from '../../../model/entities/device'
-import { EntityTestFactory } from '../../../model/entities/test/entity-test-factory'
-import { StatusCode } from '../../../model/enums/status-code'
-import { StatusMessage } from '../../../model/entities/status-message'
 import { DeviceRepository } from '../../../data-access/repositories/interfaces/device-repository'
 import { Logger } from '../../../logger/logger'
+import { StatusMessageService } from '../interfaces/status-message-service'
+import { EntityTestFactory } from '../../../model/entities/test/entity-test-factory'
+import { StatusCode } from '../../../model/enums/status-code'
 
 describe(DeviceChangedService.name, () => {
-  describe('there are no StatusMessages for the Device', () => {
-    describe('the Device is not connected', () => {
-      it('creates a new Bad StatusMessage', async () => {
-        const device: Device = EntityTestFactory.createDevice({ isConnected: false })
-        const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
+  it('calls the StatusMessageService with a StatusMessage that has the same id as the Device', () => {
+    const device: Device = EntityTestFactory.createDevice({ id: 'deviceId' })
+    const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
 
-        const statusMessageEventEmitter: StatusMessageEventEmitter = mock<StatusMessageEventEmitter>()
-        const statusMessageRepository: StatusMessageRepository = mock<StatusMessageRepository>()
+    const statusMessageService: StatusMessageService = mock<StatusMessageService>()
 
-        // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
-        createTestee({
-          statusMessageEventEmitter: instance(statusMessageEventEmitter),
-          statusMessageRepository: instance(statusMessageRepository),
-          deviceDataChangeListener: instance(deviceDataChangedListener)
-        })
+    // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
+    createTestee({ statusMessageService, deviceDataChangedListener })
 
-        await wait()
+    const [statusMessage] = capture(statusMessageService.updateStatusMessage).last()
+    expect(statusMessage.id).toBe(device.id)
+  })
 
-        const [statusMessage] = capture(statusMessageEventEmitter.emitStatusMessageEvent).last()
-        expect(statusMessage.statusCode).toBe(StatusCode.BAD)
-        verify(statusMessageRepository.createStatusMessage(anything())).once()
-      })
+  it('calls the StatusMessageService with a StatusMessage that has the Device name as title', () => {
+    const device: Device = EntityTestFactory.createDevice({ statusMessage: 'some Message' })
+    const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
+
+    const statusMessageService: StatusMessageService = mock<StatusMessageService>()
+
+    // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
+    createTestee({ statusMessageService, deviceDataChangedListener })
+
+    const [statusMessage] = capture(statusMessageService.updateStatusMessage).last()
+    expect(statusMessage.message).toBe(device.statusMessage)
+  })
+
+  describe('the Device is not connected', () => {
+    it('calls the StatusMessageService with a StatusCode BAD', () => {
+      const device: Device = EntityTestFactory.createDevice({ isConnected: false, statusCode: StatusCode.UNKNOWN })
+      const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
+
+      const statusMessageService: StatusMessageService = mock<StatusMessageService>()
+
+      // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
+      createTestee({ statusMessageService, deviceDataChangedListener })
+
+      const [statusMessage] = capture(statusMessageService.updateStatusMessage).last()
+      expect(statusMessage.statusCode).toBe(StatusCode.BAD)
     })
 
-    describe('the Device is connected', () => {
-      it('does nothing when the Device status is GOOD', async () => {
-        const device: Device = EntityTestFactory.createDevice({ isConnected: true, statusCode: StatusCode.GOOD })
-        const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
+    it('calls the StatusMessageService with a NOT_CONNECTED message', () => {
+      const device: Device = EntityTestFactory.createDevice({ isConnected: false, statusMessage: 'some message' })
+      const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
 
-        const statusMessageEventEmitter: StatusMessageEventEmitter = mock<StatusMessageEventEmitter>()
-        const statusMessageRepository: StatusMessageRepository = mock<StatusMessageRepository>()
+      const statusMessageService: StatusMessageService = mock<StatusMessageService>()
 
-        // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
-        createTestee({
-          statusMessageEventEmitter: instance(statusMessageEventEmitter),
-          statusMessageRepository: instance(statusMessageRepository),
-          deviceDataChangeListener: instance(deviceDataChangedListener)
-        })
+      // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
+      createTestee({ statusMessageService, deviceDataChangedListener })
 
-        await wait()
-
-        assertNoModifyMethodsCalled(statusMessageRepository)
-        verify(statusMessageEventEmitter.emitStatusMessageEvent(anything())).never()
-      })
-
-      it('emits a StatusMessage event for the Device', async () => {
-        const device: Device = EntityTestFactory.createDevice({ isConnected: true, statusCode: StatusCode.BAD })
-        const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
-
-        const statusMessageEventEmitter: StatusMessageEventEmitter = mock<StatusMessageEventEmitter>()
-
-        // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
-        createTestee({
-          statusMessageEventEmitter: instance(statusMessageEventEmitter),
-          deviceDataChangeListener: instance(deviceDataChangedListener)
-        })
-
-        await wait()
-
-        verify(statusMessageEventEmitter.emitStatusMessageEvent(anything())).once()
-      })
-
-      it('emits a StatusMessage event with values of the Device', async () => {
-        const device: Device = EntityTestFactory.createDevice({ isConnected: true, statusCode: StatusCode.BAD, statusMessage: 'Hello world' })
-        const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
-
-        const statusMessageEventEmitter: StatusMessageEventEmitter = mock<StatusMessageEventEmitter>()
-
-        // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
-        createTestee({
-          statusMessageEventEmitter: instance(statusMessageEventEmitter),
-          deviceDataChangeListener: instance(deviceDataChangedListener)
-        })
-
-        await wait()
-
-        const [emittedStatusMessage] = capture(statusMessageEventEmitter.emitStatusMessageEvent).last()
-        assertStatusMessageIsFromDevice(emittedStatusMessage, device)
-      })
-
-      it('saves a new StatusMessage for the Device', async () => {
-        const device: Device = EntityTestFactory.createDevice({ isConnected: true, statusCode: StatusCode.BAD })
-        const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
-
-        const statusMessageRepository: StatusMessageRepository = mock<StatusMessageRepository>()
-
-        // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
-        createTestee({
-          statusMessageRepository: instance(statusMessageRepository),
-          deviceDataChangeListener: instance(deviceDataChangedListener)
-        })
-
-        await wait()
-
-        verify(statusMessageRepository.createStatusMessage(anything())).once()
-      })
-
-      it('saves a new StatusMessage with the values for the Device', async () => {
-        const device: Device = EntityTestFactory.createDevice({ isConnected: true, statusCode: StatusCode.BAD, statusMessage: 'Hello world' })
-        const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
-
-        const statusMessageRepository: StatusMessageRepository = mock<StatusMessageRepository>()
-
-        // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
-        createTestee({
-          statusMessageRepository: instance(statusMessageRepository),
-          deviceDataChangeListener: instance(deviceDataChangedListener)
-        })
-
-        await wait()
-
-        const [savedStatusMessage] = capture(statusMessageRepository.createStatusMessage).last()
-        assertStatusMessageIsFromDevice(savedStatusMessage, device)
-      })
+      const [statusMessage] = capture(statusMessageService.updateStatusMessage).last()
+      expect(statusMessage.message).toBe('Not connected')
     })
   })
 
-  describe('there is a StatusMessage for the Device', () => {
-    describe('the Device is not connected', () => {
-      it('updates the StatusMessage to be BAD', async () => {
-        const device: Device = EntityTestFactory.createDevice({ isConnected: false })
-        const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
+  describe('the Device is connected', () => {
+    it('calls the StatusMessageService with a StatusMessage with a StatusCode matching the Device status', () => {
+      const device: Device = EntityTestFactory.createDevice({ isConnected: true, statusCode: StatusCode.WARNING })
+      const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
 
-        const statusMessageEventEmitter: StatusMessageEventEmitter = mock<StatusMessageEventEmitter>()
-        const statusMessageRepository: StatusMessageRepository = mock<StatusMessageRepository>()
-        when(statusMessageRepository.getStatusMessage(device.id)).thenReturn(Promise.resolve(EntityTestFactory.createStatusMessage()))
+      const statusMessageService: StatusMessageService = mock<StatusMessageService>()
 
-        // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
-        createTestee({
-          statusMessageEventEmitter: instance(statusMessageEventEmitter),
-          statusMessageRepository: instance(statusMessageRepository),
-          deviceDataChangeListener: instance(deviceDataChangedListener)
-        })
+      // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
+      createTestee({ statusMessageService, deviceDataChangedListener })
 
-        await wait()
-
-        const [statusMessage] = capture(statusMessageEventEmitter.emitStatusMessageEvent).last()
-        expect(statusMessage.statusCode).toBe(StatusCode.BAD)
-        verify(statusMessageRepository.updateStatusMessage(anything())).once()
-      })
+      const [statusMessage] = capture(statusMessageService.updateStatusMessage).last()
+      expect(statusMessage.statusCode).toBe(device.statusCode)
     })
 
-    describe('the Device is connected', () => {
-      describe('the saved StatusMessage is not different from the new Device', () => {
-        it('does nothing', async () => {
-          const device: Device = EntityTestFactory.createDevice({ isConnected: true })
-          const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
+    it('calls the StatusMessageService with a StatusMessage with a message matching the Device status message', () => {
+      const device: Device = EntityTestFactory.createDevice({ isConnected: true, statusMessage: 'Some message' })
+      const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
 
-          const statusMessageEventEmitter: StatusMessageEventEmitter = mock<StatusMessageEventEmitter>()
-          const statusMessageRepository: StatusMessageRepository = mock<StatusMessageRepository>()
+      const statusMessageService: StatusMessageService = mock<StatusMessageService>()
 
-          const statusMessageInDatabase: StatusMessage = createStatusMessageFromDevice(device)
-          when(statusMessageRepository.getStatusMessage(device.id)).thenReturn(Promise.resolve(statusMessageInDatabase))
+      // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
+      createTestee({ statusMessageService, deviceDataChangedListener })
 
-          // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
-          createTestee({
-            statusMessageEventEmitter: instance(statusMessageEventEmitter),
-            statusMessageRepository: instance(statusMessageRepository),
-            deviceDataChangeListener: instance(deviceDataChangedListener)
-          })
-
-          await wait()
-
-          assertNoModifyMethodsCalled(statusMessageRepository)
-          verify(statusMessageEventEmitter.emitStatusMessageEvent(anything())).never()
-        })
-      })
-
-      describe('the saved StatusMessage is different from the new Device', () => {
-        it('emits a new StatusMessage for the Device', async () => {
-          const device: Device = EntityTestFactory.createDevice({ isConnected: true, statusCode: StatusCode.UNKNOWN })
-          const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
-
-          const statusMessageEventEmitter: StatusMessageEventEmitter = mock<StatusMessageEventEmitter>()
-          const statusMessageRepository: StatusMessageRepository = mock<StatusMessageRepository>()
-
-          const statusMessageInDatabase: StatusMessage = EntityTestFactory.createStatusMessage({ id: 'differentStatusMessageId', title: 'different', statusCode: StatusCode.GOOD })
-          when(statusMessageRepository.getStatusMessage(device.id)).thenReturn(Promise.resolve(statusMessageInDatabase))
-
-          // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
-          createTestee({
-            statusMessageEventEmitter: instance(statusMessageEventEmitter),
-            statusMessageRepository: instance(statusMessageRepository),
-            deviceDataChangeListener: instance(deviceDataChangedListener)
-          })
-
-          await wait()
-
-          const [emittedStatusMessage] = capture(statusMessageEventEmitter.emitStatusMessageEvent).last()
-          expect(emittedStatusMessage).not.toBe(statusMessageInDatabase)
-          assertStatusMessageIsFromDevice(emittedStatusMessage, device)
-        })
-
-        it('deletes the saved StatusMessage when the Device status is GOOD', async () => {
-          const device: Device = EntityTestFactory.createDevice({ isConnected: true, statusCode: StatusCode.GOOD })
-          const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
-
-          const statusMessageEventEmitter: StatusMessageEventEmitter = mock<StatusMessageEventEmitter>()
-          const statusMessageRepository: StatusMessageRepository = mock<StatusMessageRepository>()
-
-          const statusMessageInDatabase: StatusMessage = EntityTestFactory.createStatusMessage({ id: 'differentStatusMessageId', title: 'different', statusCode: StatusCode.UNKNOWN })
-          when(statusMessageRepository.getStatusMessage(device.id)).thenReturn(Promise.resolve(statusMessageInDatabase))
-
-          // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
-          createTestee({
-            statusMessageEventEmitter: instance(statusMessageEventEmitter),
-            statusMessageRepository: instance(statusMessageRepository),
-            deviceDataChangeListener: instance(deviceDataChangedListener)
-          })
-
-          await wait()
-
-          verify(statusMessageRepository.deleteStatusMessage(statusMessageInDatabase.id)).once()
-          verify(statusMessageRepository.updateStatusMessage(anything())).never()
-        })
-
-        describe('Device status is not GOOD or UNKNOWN', () => {
-          it('updates the StatusMessage for the Device', async () => {
-            const device: Device = EntityTestFactory.createDevice({ isConnected: true, statusCode: StatusCode.BAD })
-            const deviceDataChangedListener: DataChangedListener<Device> = createDeviceChangedListenerMock(device)
-
-            const statusMessageEventEmitter: StatusMessageEventEmitter = mock<StatusMessageEventEmitter>()
-            const statusMessageRepository: StatusMessageRepository = mock<StatusMessageRepository>()
-
-            const statusMessageInDatabase: StatusMessage = EntityTestFactory.createStatusMessage({ id: 'differentStatusMessageId', title: 'different', statusCode: StatusCode.UNKNOWN })
-            when(statusMessageRepository.getStatusMessage(device.id)).thenReturn(Promise.resolve(statusMessageInDatabase))
-
-            // This is our testee. The flow starts in the constructor, so we just need to instantiate it.
-            createTestee({
-              statusMessageEventEmitter: instance(statusMessageEventEmitter),
-              statusMessageRepository: instance(statusMessageRepository),
-              deviceDataChangeListener: instance(deviceDataChangedListener)
-            })
-
-            await wait()
-
-            const [updatedStatusMessage] = capture(statusMessageRepository.updateStatusMessage).last()
-            assertStatusMessageIsFromDevice(updatedStatusMessage, device)
-          })
-        })
-      })
+      const [statusMessage] = capture(statusMessageService.updateStatusMessage).last()
+      expect(statusMessage.message).toBe(device.statusMessage)
     })
   })
 })
 
 function createTestee(params?: {
-  statusMessageEventEmitter?: StatusMessageEventEmitter,
-  statusMessageRepository?: StatusMessageRepository,
+  statusMessageService?: StatusMessageService,
   deviceRepository?: DeviceRepository,
-  deviceDataChangeListener?: DataChangedListener<Device>,
+  deviceDataChangedListener?: DataChangedListener<Device>,
   logger?: Logger
 }): DeviceChangedService {
   let deviceRepository: DeviceRepository
   if (!params?.deviceRepository) {
     const deviceRepositoryMock: DeviceRepository = mock<DeviceRepository>()
     when(deviceRepositoryMock.getDevices()).thenReturn(Promise.resolve([]))
-    deviceRepository = instance(deviceRepositoryMock)
+    deviceRepository = deviceRepositoryMock
   } else {
     deviceRepository = params.deviceRepository
   }
 
   return new DeviceChangedService(
-    params?.statusMessageEventEmitter ?? instance(mock<StatusMessageEventEmitter>()),
-    params?.statusMessageRepository ?? instance(mock<StatusMessageRepository>()),
-    deviceRepository,
-    params?.deviceDataChangeListener ?? instance(mock<DataChangedListener<Device>>()),
-    params?.logger ?? instance(mock<Logger>())
+    instance(params?.statusMessageService ?? mock<StatusMessageService>()),
+    instance(deviceRepository),
+    instance(params?.deviceDataChangedListener ?? mock<DataChangedListener<Device>>()),
+    instance(params?.logger ?? mock<Logger>())
   )
 }
 
@@ -285,31 +119,4 @@ function createDeviceChangedListenerMock(device: Device): DataChangedListener<De
   const deviceDataChangedListener: DataChangedListener<Device> = mock<DataChangedListener<Device>>()
   when(deviceDataChangedListener.onUpdated(anything())).thenCall(callback => callback(device))
   return deviceDataChangedListener
-}
-
-function wait(): Promise<void> {
-  return new Promise(f => setTimeout(f, 10))
-}
-
-function assertNoModifyMethodsCalled(statusMessageRepository: StatusMessageRepository): void {
-  verify(statusMessageRepository.createStatusMessage(anything())).never()
-  verify(statusMessageRepository.updateStatusMessage(anything())).never()
-  verify(statusMessageRepository.deleteStatusMessage(anything())).never()
-}
-
-function assertStatusMessageIsFromDevice(emittedStatusMessage: StatusMessage, device: Device): void {
-  const statusMessageFromDevice: StatusMessage = createStatusMessageFromDevice(device)
-  expect(emittedStatusMessage.id).toBe(statusMessageFromDevice.id)
-  expect(emittedStatusMessage.statusCode).toBe(statusMessageFromDevice.statusCode)
-  expect(emittedStatusMessage.title).toBe(statusMessageFromDevice.title)
-  expect(emittedStatusMessage.message).toBe(statusMessageFromDevice.message)
-}
-
-function createStatusMessageFromDevice(device: Device): StatusMessage {
-  return {
-    id: device.id,
-    title: device.name,
-    statusCode: device.statusCode,
-    message: device.statusMessage
-  }
 }

--- a/src/business-logic/services/test/status-message-service-implementation.spec.ts
+++ b/src/business-logic/services/test/status-message-service-implementation.spec.ts
@@ -1,0 +1,127 @@
+import { StatusMessageServiceImplementation } from '../status-message-service-implementation'
+import { StatusMessageService } from '../interfaces/status-message-service'
+import { anything, instance, mock, verify, when } from '@typestrong/ts-mockito'
+import { StatusMessageEventEmitter } from '../interfaces/status-message-event-emitter'
+import { StatusMessageRepository } from '../../../data-access/repositories/interfaces/status-message-repository'
+import { EntityTestFactory } from '../../../model/entities/test/entity-test-factory'
+import { StatusCode } from '../../../model/enums/status-code'
+import { StatusMessage } from '../../../model/entities/status-message'
+
+describe(StatusMessageServiceImplementation.name, () => {
+  describe(StatusMessageServiceImplementation.prototype.updateStatusMessage.name, () => {
+    describe('the StatusMessage does not already exist in the database', () => {
+      it('does nothing when the StatusMessage is GOOD', async () => {
+        const statusMessageEventEmitter: StatusMessageEventEmitter = mock<StatusMessageEventEmitter>()
+        const statusMessageRepository: StatusMessageRepository = mock<StatusMessageRepository>()
+        const statusMessage: StatusMessage = EntityTestFactory.createStatusMessage({ statusCode: StatusCode.GOOD })
+
+        const testee: StatusMessageService = createTestee({ statusMessageEventEmitter, statusMessageRepository })
+        await testee.updateStatusMessage(statusMessage)
+
+        verify(statusMessageEventEmitter.emitStatusMessageEvent(anything())).never()
+        assertNoModifyMethodsCalled(statusMessageRepository)
+      })
+
+      describe('the StatusMessage is BAD', () => {
+        it('emits a StatusMessageEvent with the StatusMessage', async () => {
+          const statusMessageEventEmitter: StatusMessageEventEmitter = mock<StatusMessageEventEmitter>()
+          const statusMessage: StatusMessage = EntityTestFactory.createStatusMessage({ statusCode: StatusCode.BAD })
+
+          const testee: StatusMessageService = createTestee({ statusMessageEventEmitter })
+          await testee.updateStatusMessage(statusMessage)
+
+          verify(statusMessageEventEmitter.emitStatusMessageEvent(statusMessage)).once()
+        })
+
+        it('saves the StatusMessage to the database', async () => {
+          const statusMessageRepository: StatusMessageRepository = mock<StatusMessageRepository>()
+          const statusMessage: StatusMessage = EntityTestFactory.createStatusMessage({ statusCode: StatusCode.BAD })
+
+          const testee: StatusMessageService = createTestee({ statusMessageRepository })
+          await testee.updateStatusMessage(statusMessage)
+
+          verify(statusMessageRepository.createStatusMessage(statusMessage)).once()
+        })
+      })
+    })
+
+    describe('the statusMessage exist in the database', () => {
+      it ('does nothing when the StatusMessage has the same StatusCode and Message as the one in the database', async () => {
+        const statusMessage: StatusMessage = EntityTestFactory.createStatusMessage({ statusCode: StatusCode.BAD, message: 'Some message' })
+
+        const statusMessageEventEmitter: StatusMessageEventEmitter = mock<StatusMessageEventEmitter>()
+        const statusMessageRepository: StatusMessageRepository = mock<StatusMessageRepository>()
+        when(statusMessageRepository.getStatusMessage(statusMessage.id)).thenReturn(Promise.resolve(statusMessage))
+
+        const testee: StatusMessageService = createTestee({ statusMessageEventEmitter, statusMessageRepository })
+        await testee.updateStatusMessage(statusMessage)
+
+        verify(statusMessageEventEmitter.emitStatusMessageEvent(anything())).never()
+        assertNoModifyMethodsCalled(statusMessageRepository)
+      })
+
+      describe('the StatusMessage is different from the one in the database', () => {
+        it('emits a StatusMessageEvent for the new StatusMessage', async () => {
+          const statusMessageFromDatabase: StatusMessage = EntityTestFactory.createStatusMessage({ message: 'Some message' })
+          const newStatusMessage: StatusMessage = EntityTestFactory.createStatusMessage({ message: 'Some other message' })
+
+          const statusMessageEventEmitter: StatusMessageEventEmitter = mock<StatusMessageEventEmitter>()
+          const statusMessageRepository: StatusMessageRepository = mock<StatusMessageRepository>()
+          when(statusMessageRepository.getStatusMessage(statusMessageFromDatabase.id)).thenReturn(Promise.resolve(statusMessageFromDatabase))
+
+          const testee: StatusMessageService = createTestee({ statusMessageEventEmitter, statusMessageRepository })
+          await testee.updateStatusMessage(newStatusMessage)
+
+          verify(statusMessageEventEmitter.emitStatusMessageEvent(newStatusMessage)).once()
+        })
+
+        it('deletes the StatusMessage from the database when the Status is GOOD', async () => {
+          const statusMessageFromDatabase: StatusMessage = EntityTestFactory.createStatusMessage({ message: 'Some message' })
+          const newStatusMessage: StatusMessage = EntityTestFactory.createStatusMessage({ statusCode: StatusCode.GOOD, message: 'Some other message' })
+
+          const statusMessageRepository: StatusMessageRepository = mock<StatusMessageRepository>()
+          when(statusMessageRepository.getStatusMessage(statusMessageFromDatabase.id)).thenReturn(Promise.resolve(statusMessageFromDatabase))
+
+          const testee: StatusMessageService = createTestee({ statusMessageRepository })
+          await testee.updateStatusMessage(newStatusMessage)
+
+          verify(statusMessageRepository.deleteStatusMessage(newStatusMessage.id)).once()
+          verify(statusMessageRepository.createStatusMessage(anything())).never()
+          verify(statusMessageRepository.updateStatusMessage(anything())).never()
+        })
+
+        it('updates the StatusMessage in the database when the Status is not GOOD',
+          async () => {
+            const statusMessageFromDatabase: StatusMessage = EntityTestFactory.createStatusMessage({message: 'Some message'})
+            const newStatusMessage: StatusMessage = EntityTestFactory.createStatusMessage({ statusCode: StatusCode.BAD, message: 'Some other message' })
+
+            const statusMessageRepository: StatusMessageRepository = mock<StatusMessageRepository>()
+            when(statusMessageRepository.getStatusMessage(statusMessageFromDatabase.id)).thenReturn(Promise.resolve(statusMessageFromDatabase))
+
+            const testee: StatusMessageService = createTestee({statusMessageRepository})
+            await testee.updateStatusMessage(newStatusMessage)
+
+            verify(statusMessageRepository.updateStatusMessage(newStatusMessage)).once()
+            verify(statusMessageRepository.createStatusMessage(anything())).never()
+            verify(statusMessageRepository.deleteStatusMessage(anything())).never()
+          })
+      })
+    })
+  })
+})
+
+function createTestee(params?: {
+  statusMessageEventEmitter?: StatusMessageEventEmitter,
+  statusMessageRepository?: StatusMessageRepository
+}): StatusMessageService {
+  return new StatusMessageServiceImplementation(
+    instance(params?.statusMessageEventEmitter ?? mock<StatusMessageEventEmitter>()),
+    instance(params?.statusMessageRepository ?? mock<StatusMessageRepository>()),
+  )
+}
+
+function assertNoModifyMethodsCalled(statusMessageRepository: StatusMessageRepository): void {
+  verify(statusMessageRepository.createStatusMessage(anything())).never()
+  verify(statusMessageRepository.updateStatusMessage(anything())).never()
+  verify(statusMessageRepository.deleteStatusMessage(anything())).never()
+}

--- a/src/data-access/facades/repository-facade.ts
+++ b/src/data-access/facades/repository-facade.ts
@@ -69,11 +69,17 @@ import { ShowStyle } from '../../model/entities/show-style'
 import {
   MongoShowStyleConfigurationChangedListener
 } from '../repositories/mongo/mongo-show-style-configuration-changed-listener'
+import { Database } from '../repositories/interfaces/database'
 
 export class RepositoryFacade {
+
+  public static getDatabase(): Database {
+    return MongoDatabase.getInstance(LoggerFacade.createLogger())
+  }
+
   public static createRundownRepository(): RundownRepository {
     const mongoRundownRepository: RundownRepository = new MongoRundownRepository(
-      RepositoryFacade.getMongoDatabaseInstance(),
+      MongoDatabase.getInstance(LoggerFacade.createLogger()),
       new MongoEntityConverter(),
       RepositoryFacade.createSegmentRepository(),
       RepositoryFacade.createPieceRepository()
@@ -81,13 +87,9 @@ export class RepositoryFacade {
     return CachedRundownRepository.getInstance(mongoRundownRepository, LoggerFacade.createLogger())
   }
 
-  private static getMongoDatabaseInstance(): MongoDatabase {
-    return MongoDatabase.getInstance(LoggerFacade.createLogger())
-  }
-
   public static createIngestedRundownRepository(): IngestedRundownRepository {
     return new MongoIngestedRundownRepository(
-      RepositoryFacade.getMongoDatabaseInstance(),
+      MongoDatabase.getInstance(LoggerFacade.createLogger()),
       new MongoIngestedEntityConverter(),
       RepositoryFacade.createRundownBaselineRepository(),
       RepositoryFacade.createIngestedSegmentRepository()
@@ -96,19 +98,19 @@ export class RepositoryFacade {
 
   public static createIngestedRundownChangeListener(): DataChangedListener<IngestedRundown> {
     return new MongoIngestedRundownChangedListener(
-      RepositoryFacade.getMongoDatabaseInstance(),
+      MongoDatabase.getInstance(LoggerFacade.createLogger()),
       RepositoryFacade.createIngestedRundownRepository(),
       LoggerFacade.createLogger()
     )
   }
 
   public static createRundownBaselineRepository(): RundownBaselineRepository {
-    return new MongoRundownBaselineRepository(RepositoryFacade.getMongoDatabaseInstance())
+    return new MongoRundownBaselineRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()))
   }
 
   public static createSegmentRepository(): SegmentRepository {
     const mongoSegmentRepository: SegmentRepository = new MongoSegmentRepository(
-      RepositoryFacade.getMongoDatabaseInstance(),
+      MongoDatabase.getInstance(LoggerFacade.createLogger()),
       new MongoEntityConverter(),
       RepositoryFacade.createPartRepository()
     )
@@ -117,7 +119,7 @@ export class RepositoryFacade {
 
   public static createIngestedSegmentRepository(): IngestedSegmentRepository {
     return new MongoIngestedSegmentRepository(
-      RepositoryFacade.getMongoDatabaseInstance(),
+      MongoDatabase.getInstance(LoggerFacade.createLogger()),
       new MongoIngestedEntityConverter(),
       RepositoryFacade.createIngestedPartRepository()
     )
@@ -125,7 +127,7 @@ export class RepositoryFacade {
 
   public static createIngestedSegmentChangedListener(): DataChangedListener<IngestedSegment> {
     return new MongoIngestedSegmentChangedListener(
-      RepositoryFacade.getMongoDatabaseInstance(),
+      MongoDatabase.getInstance(LoggerFacade.createLogger()),
       RepositoryFacade.createIngestedSegmentRepository(),
       LoggerFacade.createLogger()
     )
@@ -133,7 +135,7 @@ export class RepositoryFacade {
 
   public static createPartRepository(): PartRepository {
     const mongoPartRepository: PartRepository = new MongoPartRepository(
-      RepositoryFacade.getMongoDatabaseInstance(),
+      MongoDatabase.getInstance(LoggerFacade.createLogger()),
       new MongoEntityConverter(),
       RepositoryFacade.createPieceRepository()
     )
@@ -142,7 +144,7 @@ export class RepositoryFacade {
 
   public static createIngestedPartRepository(): IngestedPartRepository {
     return new MongoIngestedPartRepository(
-      RepositoryFacade.getMongoDatabaseInstance(),
+      MongoDatabase.getInstance(LoggerFacade.createLogger()),
       new MongoIngestedEntityConverter(),
       RepositoryFacade.createIngestedPieceRepository()
     )
@@ -150,7 +152,7 @@ export class RepositoryFacade {
 
   public static createIngestedPartChangedListener(): DataChangedListener<IngestedPart> {
     return new MongoIngestedPartChangedListener(
-      RepositoryFacade.getMongoDatabaseInstance(),
+      MongoDatabase.getInstance(LoggerFacade.createLogger()),
       RepositoryFacade.createIngestedPartRepository(),
       LoggerFacade.createLogger()
     )
@@ -158,22 +160,22 @@ export class RepositoryFacade {
 
   public static createMediaChangedListener(): DataChangedListener<Media> {
     return new MongoMediaChangedListener(
-      RepositoryFacade.getMongoDatabaseInstance(),
+      MongoDatabase.getInstance(LoggerFacade.createLogger()),
       LoggerFacade.createLogger(),
       RepositoryFacade.createMediaRepository()
     )
   }
 
   public static createPieceRepository(): PieceRepository {
-    return new MongoPieceRepository(RepositoryFacade.getMongoDatabaseInstance(), new MongoEntityConverter())
+    return new MongoPieceRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter())
   }
 
   public static createIngestedPieceRepository(): IngestedPieceRepository {
-    return new MongoIngestedPieceRepository(RepositoryFacade.getMongoDatabaseInstance(), new MongoIngestedEntityConverter())
+    return new MongoIngestedPieceRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoIngestedEntityConverter())
   }
 
   public static createTimelineRepository(): TimelineRepository {
-    return new MongoTimelineRepository(RepositoryFacade.getMongoDatabaseInstance(), new MongoEntityConverter())
+    return new MongoTimelineRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter())
   }
 
   public static createConfigurationRepository(): ConfigurationRepository {
@@ -185,31 +187,35 @@ export class RepositoryFacade {
   }
 
   private static createStudioRepository(): StudioRepository {
-    return new MongoStudioRepository(RepositoryFacade.getMongoDatabaseInstance(), new MongoEntityConverter())
+    return new MongoStudioRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter())
   }
 
   private static createShowStyleRepository(): ShowStyleRepository {
-    return new MongoShowStyleRepository(RepositoryFacade.getMongoDatabaseInstance(), new MongoEntityConverter())
+    return new MongoShowStyleRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter())
   }
 
   public static createShowStyleChangedListener(): DataChangedListener<ShowStyle> {
-    return new MongoShowStyleConfigurationChangedListener(RepositoryFacade.getMongoDatabaseInstance(), LoggerFacade.createLogger())
+    return new MongoShowStyleConfigurationChangedListener(MongoDatabase.getInstance(LoggerFacade.createLogger()), LoggerFacade.createLogger())
   }
 
   public static createShelfConfigurationRepository(): ShelfConfigurationRepository {
-    return new MongoShelfRepository(RepositoryFacade.getMongoDatabaseInstance(), this.createUuidGenerator())
+    return new MongoShelfRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), this.createUuidGenerator())
   }
 
   public static createActionRepository(): ActionRepository {
-    return new MongoActionRepository(RepositoryFacade.getMongoDatabaseInstance())
+    return new MongoActionRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()))
   }
 
   public static createActionTriggerRepository(): ActionTriggerRepository {
-    return new MongoActionTriggerRepository(RepositoryFacade.getMongoDatabaseInstance(), this.createUuidGenerator())
+    return new MongoActionTriggerRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), this.createUuidGenerator())
   }
 
   public static createShowStyleVariantRepository(): ShowStyleVariantRepository {
-    return new MongoShowStyleVariantRepository(RepositoryFacade.getMongoDatabaseInstance(), new MongoEntityConverter(), this.createRundownRepository())
+    return new MongoShowStyleVariantRepository(
+      MongoDatabase.getInstance(LoggerFacade.createLogger()),
+      new MongoEntityConverter(),
+      this.createRundownRepository()
+    )
   }
 
   public static createActionManifestRepository(): ActionManifestRepository {
@@ -217,31 +223,35 @@ export class RepositoryFacade {
   }
 
   private static createAdLibActionRepository(): ActionManifestRepository {
-    return new MongoAdLibActionsRepository(RepositoryFacade.getMongoDatabaseInstance())
+    return new MongoAdLibActionsRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()))
   }
 
   private static createAdLibPieceRepository(): ActionManifestRepository {
-    return new MongoAdLibPieceRepository(RepositoryFacade.getMongoDatabaseInstance())
+    return new MongoAdLibPieceRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()))
   }
 
   public static createMediaRepository(): MediaRepository {
-    return new MongoMediaRepository(RepositoryFacade.getMongoDatabaseInstance(), new MongoEntityConverter())
+    return new MongoMediaRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter())
   }
 
   public static createSystemInformationRepository(): SystemInformationRepository {
-    return new MongoSystemInformationRepository(RepositoryFacade.getMongoDatabaseInstance(), new MongoEntityConverter())
+    return new MongoSystemInformationRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter())
   }
 
   public static createDeviceDataChangedListener(): DataChangedListener<Device> {
-    return new MongoDeviceChangedListener(this.getMongoDatabaseInstance(), new MongoEntityConverter(), LoggerFacade.createLogger())
+    return new MongoDeviceChangedListener(
+      MongoDatabase.getInstance(LoggerFacade.createLogger()),
+      new MongoEntityConverter(),
+      LoggerFacade.createLogger()
+    )
   }
 
   public static createDeviceRepository(): DeviceRepository {
-    return new MongoDeviceRepository(this.getMongoDatabaseInstance(), new MongoEntityConverter())
+    return new MongoDeviceRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter())
   }
 
   public static createStatusMessageRepository(): StatusMessageRepository {
-    return new MongoStatusMessageRepository(this.getMongoDatabaseInstance())
+    return new MongoStatusMessageRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()))
   }
 
   private static createUuidGenerator(): UuidGenerator {

--- a/src/data-access/facades/repository-facade.ts
+++ b/src/data-access/facades/repository-facade.ts
@@ -65,6 +65,10 @@ import { StatusMessageRepository } from '../repositories/interfaces/status-messa
 import { MongoStatusMessageRepository } from '../repositories/mongo/mongo-status-message-repository'
 import { DeviceRepository } from '../repositories/interfaces/device-repository'
 import { MongoDeviceRepository } from '../repositories/mongo/mongo-device-repository'
+import { ShowStyle } from '../../model/entities/show-style'
+import {
+  MongoShowStyleConfigurationChangedListener
+} from '../repositories/mongo/mongo-show-style-configuration-changed-listener'
 
 export class RepositoryFacade {
   public static createRundownRepository(): RundownRepository {
@@ -186,6 +190,10 @@ export class RepositoryFacade {
 
   private static createShowStyleRepository(): ShowStyleRepository {
     return new MongoShowStyleRepository(RepositoryFacade.getMongoDatabaseInstance(), new MongoEntityConverter())
+  }
+
+  public static createShowStyleChangedListener(): DataChangedListener<ShowStyle> {
+    return new MongoShowStyleConfigurationChangedListener(RepositoryFacade.getMongoDatabaseInstance(), LoggerFacade.createLogger())
   }
 
   public static createShelfConfigurationRepository(): ShelfConfigurationRepository {

--- a/src/data-access/repositories/interfaces/database.ts
+++ b/src/data-access/repositories/interfaces/database.ts
@@ -1,0 +1,3 @@
+export interface Database {
+  connect(): Promise<void>
+}

--- a/src/data-access/repositories/interfaces/status-message-repository.ts
+++ b/src/data-access/repositories/interfaces/status-message-repository.ts
@@ -3,6 +3,7 @@ import { StatusMessage } from '../../../model/entities/status-message'
 export interface StatusMessageRepository {
   getStatusMessage(id: string): Promise<StatusMessage>
   getAllStatusMessages(): Promise<StatusMessage[]>
+  getStatusMessagesWithIdPrefix(idPrefix: string): Promise<StatusMessage[]>
   createStatusMessage(statusMessage: StatusMessage): Promise<StatusMessage>
   updateStatusMessage(statusMessage: StatusMessage): Promise<StatusMessage>
   deleteStatusMessage(id: string): Promise<void>

--- a/src/data-access/repositories/mongo/mongo-database.ts
+++ b/src/data-access/repositories/mongo/mongo-database.ts
@@ -3,6 +3,7 @@ import { Collection } from 'mongodb'
 import { DatabaseNotConnectedException } from '../../../model/exceptions/database-not-connected-exception'
 import { MongoId } from './mongo-entity-converter'
 import { Logger } from '../../../logger/logger'
+import { Database } from '../interfaces/database'
 
 const MONGO_CONNECTION_STRING: string = process.env.MONGO_URL ?? 'mongodb://localhost:3001'
 const MONGO_DB_NAME: string = getMongoDatabaseName()
@@ -12,7 +13,7 @@ function getMongoDatabaseName(): string {
   return mongoUrlPattern.exec(MONGO_CONNECTION_STRING)?.groups?.databaseName ?? 'meteor'
 }
 
-export class MongoDatabase {
+export class MongoDatabase implements Database {
   private static instance: MongoDatabase
 
   public static getInstance(logger: Logger): MongoDatabase {
@@ -30,11 +31,13 @@ export class MongoDatabase {
 
   private constructor(logger: Logger) {
     this.logger = logger.tag(MongoDatabase.name)
-    this.connectToDatabase()
-      .catch((reason) => this.logger.data(reason).error('Failed connecting to mongo database.'))
   }
 
-  private async connectToDatabase(): Promise<void> {
+  public async connect(): Promise<void> {
+    await this.connectToMongoDatabase()
+  }
+
+  private async connectToMongoDatabase(): Promise<void> {
     if (this.db) {
       this.logger.info('Already connected to database. Skipping reconnection...')
       return

--- a/src/data-access/repositories/mongo/mongo-database.ts
+++ b/src/data-access/repositories/mongo/mongo-database.ts
@@ -68,6 +68,10 @@ export class MongoDatabase implements Database {
   }
 
   public onConnect(callbackIdentifier: string, callback: () => void): void {
+    if (this.db) {
+      callback()
+      return
+    }
     this.onConnectCallbacks.set(callbackIdentifier, callback)
   }
 }

--- a/src/data-access/repositories/mongo/mongo-show-style-configuration-changed-listener.ts
+++ b/src/data-access/repositories/mongo/mongo-show-style-configuration-changed-listener.ts
@@ -1,0 +1,57 @@
+import { DataChangedListener } from '../interfaces/data-changed-listener'
+import { ShowStyle } from '../../../model/entities/show-style'
+import { MongoDatabase } from './mongo-database'
+import { BaseMongoRepository } from './base-mongo-repository'
+import { ChangeStream, ChangeStreamDocument, ChangeStreamOptions } from 'mongodb'
+import { MongoIngestedRundown } from './mongo-ingested-entity-converter'
+import { Logger } from '../../../logger/logger'
+import { UnsupportedOperationException } from '../../../model/exceptions/unsupported-operation-exception'
+
+const SHOW_STYLE_CONFIGURATION_COLLECTION_NAME: string = 'showStyleBases'
+
+export class MongoShowStyleConfigurationChangedListener extends BaseMongoRepository implements DataChangedListener<ShowStyle> {
+
+  private readonly logger: Logger
+
+  private onUpdatedCallback: (showStyle: ShowStyle) => void
+
+  constructor(mongoDatabase: MongoDatabase, logger: Logger) {
+    super(mongoDatabase)
+    this.logger = logger.tag(MongoShowStyleConfigurationChangedListener.name)
+    mongoDatabase.onConnect(SHOW_STYLE_CONFIGURATION_COLLECTION_NAME, () => this.listenForChanges())
+  }
+
+  protected getCollectionName(): string {
+    return SHOW_STYLE_CONFIGURATION_COLLECTION_NAME
+  }
+
+  protected listenForChanges(): void {
+    const options: ChangeStreamOptions = { fullDocument: 'updateLookup' }
+    const changeStream: ChangeStream = this.getCollection().watch<MongoIngestedRundown, ChangeStreamDocument<ShowStyle>>([], options)
+    changeStream.on('change', () => this.onChange())
+    this.logger.debug('Listening for ShowStyleConfiguration collection changes...')
+  }
+
+  private onChange(): void {
+    // We just want to notify that a changed has been made
+    this.onUpdatedCallback({} as ShowStyle)
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public onCreated(_onCreatedCallback: (showStyle: ShowStyle) => void): void {
+    throw new UnsupportedOperationException(
+      `${MongoShowStyleConfigurationChangedListener.prototype.onCreated.name} is not supported in ${MongoShowStyleConfigurationChangedListener.name}`
+    )
+  }
+
+  public onUpdated(onUpdatedCallback: (showStyle: ShowStyle) => void): void {
+    this.onUpdatedCallback = onUpdatedCallback
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public onDeleted(_onDeletedCallback: (id: string) => void): void {
+    throw new UnsupportedOperationException(
+      `${MongoShowStyleConfigurationChangedListener.prototype.onDeleted.name} is not supported in ${MongoShowStyleConfigurationChangedListener.name}`
+    )
+  }
+}

--- a/src/data-access/repositories/mongo/mongo-status-message-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-status-message-repository.ts
@@ -27,13 +27,13 @@ export class MongoStatusMessageRepository extends BaseMongoRepository implements
 
   public async getAllStatusMessages(): Promise<StatusMessage[]> {
     this.assertDatabaseConnection(this.getAllStatusMessages.name)
-    return await this.getCollection().find<StatusMessage>({}).toArray()
+    return this.getCollection().find<StatusMessage>({}).toArray()
   }
 
   public async getStatusMessagesWithIdPrefix(idPrefix: string): Promise<StatusMessage[]> {
     this.assertDatabaseConnection(this.getStatusMessagesWithIdPrefix.name)
-    return await this.getCollection().find<StatusMessage>({
-      id: new RegExp(idPrefix, 'g')
+    return this.getCollection().find<StatusMessage>({
+      id: new RegExp(`^${idPrefix}`, 'g')
     }).toArray()
   }
 

--- a/src/data-access/repositories/mongo/mongo-status-message-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-status-message-repository.ts
@@ -30,6 +30,13 @@ export class MongoStatusMessageRepository extends BaseMongoRepository implements
     return await this.getCollection().find<StatusMessage>({}).toArray()
   }
 
+  public async getStatusMessagesWithIdPrefix(idPrefix: string): Promise<StatusMessage[]> {
+    this.assertDatabaseConnection(this.getStatusMessagesWithIdPrefix.name)
+    return await this.getCollection().find<StatusMessage>({
+      id: new RegExp(idPrefix, 'g')
+    }).toArray()
+  }
+
   public async createStatusMessage(statusMessage: StatusMessage): Promise<StatusMessage> {
     this.assertDatabaseConnection(this.createStatusMessage.name)
     await this.getCollection().updateOne({ id: statusMessage.id }, { $set: statusMessage }, { upsert: true})

--- a/src/model/value-objects/blueprint.ts
+++ b/src/model/value-objects/blueprint.ts
@@ -5,8 +5,9 @@ import { Timeline } from '../entities/timeline'
 import { Configuration } from '../entities/configuration'
 import { OnTimelineGenerateResult } from './on-timeline-generate-result'
 import { Action, ActionManifest, MutateActionMethods } from '../entities/action'
+import { StatusMessage } from '../entities/status-message'
 
-export type Blueprint = BlueprintOnTimelineGenerate & BlueprintGetEndStateForPart & BlueprintGenerateActions
+export type Blueprint = BlueprintOnTimelineGenerate & BlueprintGetEndStateForPart & BlueprintGenerateActions & BlueprintValidateConfiguration
 
 export interface BlueprintOnTimelineGenerate {
   onTimelineGenerate(
@@ -43,4 +44,13 @@ export interface BlueprintGenerateActions {
    * Any Action not interested in mutating its data at execution time can simply ignore this method.
    */
   getMutateActionMethods?(action: Action): MutateActionMethods[]
+}
+
+export interface BlueprintValidateConfiguration {
+  /**
+   * Validates the configuration.
+   * Returns a list of StatusMessages where each StatusMessage is an error with the configuration.
+   * The StatusMessages will be saved by SofieServer and all clients will be notified about them.
+   */
+  validateConfiguration(configuration: Configuration): StatusMessage[]
 }

--- a/src/presentation/index.ts
+++ b/src/presentation/index.ts
@@ -65,6 +65,7 @@ function startSystemServices(): void {
   ServiceFacade.createIngestService()
   ServiceFacade.createMediaDataChangeService()
   ServiceFacade.createDeviceDataChangedService()
+  ServiceFacade.createConfigurationDataChangedService()
 }
 
 startSofieServer()

--- a/src/presentation/index.ts
+++ b/src/presentation/index.ts
@@ -66,7 +66,7 @@ async function connectToDatabase(): Promise<void> {
   const logger: Logger = LoggerFacade.createLogger().tag('startup')
   await RepositoryFacade.getDatabase()
     .connect()
-    .catch((reason) => logger.data(reason).error('### Failed to connect to database ###'))
+    .catch((reason) => logger.data(reason).error('Failed to connect to database'))
 }
 
 function startSystemServices(): void {
@@ -77,4 +77,4 @@ function startSystemServices(): void {
   ServiceFacade.createConfigurationDataChangedService()
 }
 
-startSofieServer().catch((error) => LoggerFacade.createLogger().tag('startup').data(error).error('### Unable to start Sofie Server ###'))
+startSofieServer().catch((error) => LoggerFacade.createLogger().tag('startup').data(error).error('Unable to start Sofie Server'))


### PR DESCRIPTION
Introduce `BlueprintValidateConfiguration` which is a callback function that SofieServer can call in Blueprints in order to validate the company spcific Blueprint configurations.

The callback returns a list of `StatusMessages` that each refers to an error in the configuration.
SofieServer will notify all clients of these errors and when the error is no longer there, it will automatically notify the clients about this as well. In this implementation we are only validating `GraphicsSchemas`, but it's easy to extend as needed.

For now SofieServer is listening for whenever the ShowStyle collection changes in the database and then validates the configuration. Once we are no longer reliant on Core, we can call the ValidateConfiguration just before we save updates from the ConfigurationController. Note: Changes in the Studio collection is currently not being listened to and we would need to listen to that as well in order to react to Studio configuration changes.

This PR also moves the logic for checking whether a StatusMessage is new or not, or what else need to happen with it, away from `DeviceChangedService` and into its own `StatusMessageService`.