### PR TITLE
SOF-1826 Incorrect Next Part on Server restart

### DIFF
--- a/src/data-access/repositories/mongo/mongo-rundown-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-rundown-repository.ts
@@ -60,7 +60,7 @@ export class MongoRundownRepository extends BaseMongoRepository implements Rundo
   public async saveRundown(rundown: Rundown): Promise<void> {
     this.assertDatabaseConnection(this.saveRundown.name)
     const mongoRundown: MongoRundown = this.mongoEntityConverter.convertToMongoRundown(rundown)
-    await this.getCollection().updateOne({ _id: mongoRundown._id }, { $set: mongoRundown }, { upsert: true, ignoreUndefined: true })
+    await this.getCollection().replaceOne({ _id: mongoRundown._id }, mongoRundown, { upsert: true, ignoreUndefined: true })
 
     await Promise.all([
       ...rundown.getSegments().map(segment => this.segmentRepository.saveSegment(segment)),

--- a/src/model/entities/rundown.ts
+++ b/src/model/entities/rundown.ts
@@ -79,6 +79,8 @@ export class Rundown extends BasicRundown {
       this.activeCursor = rundown.alreadyActiveProperties.activeCursor
       this.nextCursor = rundown.alreadyActiveProperties.nextCursor
       this.infinitePieces = rundown.alreadyActiveProperties.infinitePieces ?? new Map()
+
+      this.markNextPart()
     }
   }
 

--- a/src/model/entities/test/rundown.spec.ts
+++ b/src/model/entities/test/rundown.spec.ts
@@ -94,6 +94,41 @@ describe(Rundown.name, () => {
             expect(rundown.getNextSegment()).toBe(nextSegment)
             expect(rundown.getInfinitePieces()).toContain(piece)
           })
+
+          it('marks the next Part as next', () => {
+            const activePart: Part = EntityTestFactory.createPart({ id: 'activePart' })
+            const nextPart: Part = EntityTestFactory.createPart({ id: 'nextPart', isNext: false }) // Needs to be false, so we can verify it being set to true.
+            const activeSegment: Segment = EntityTestFactory.createSegment({
+              id: 'activeSegment',
+            })
+            const nextSegment: Segment = EntityTestFactory.createSegment({
+              id: 'nextSegment',
+            })
+            const piece: Piece = EntityTestFactory.createPiece({
+              pieceLifespan: PieceLifespan.SPANNING_UNTIL_RUNDOWN_END,
+            })
+
+            const rundownInterface: RundownInterface = {
+              mode: RundownMode.ACTIVE,
+              alreadyActiveProperties: {
+                activeCursor: {
+                  part: activePart,
+                  segment: activeSegment,
+                  owner: Owner.SYSTEM
+                },
+                nextCursor: {
+                  part: nextPart,
+                  segment: nextSegment,
+                  owner: Owner.SYSTEM
+                },
+                infinitePieces: new Map([[piece.layer, piece]]),
+              },
+            } as RundownInterface
+
+            expect(nextPart.isNext()).toBeFalsy()
+            new Rundown(rundownInterface)
+            expect(nextPart.isNext()).toBeTruthy()
+          })
         })
       })
     })


### PR DESCRIPTION
Since MongoDB serializes undefined values to `null` in the database, we had given the `ignoreUndefined: true` option when updating our Rundowns. This unfortunately means, that values that we have marked as undefined with the intentation to delete it, was not being deleted from the database.
We still need the `ignoreUndefined: true`, so instead of using the `updateOne()` method of MongoDB, we are now using the `replaceOne()` method instead.

This, however, did not solve the entire problem (only part of it). Doing the resynchronization between the Ingested entities and the "executed" entities the next Part was never being marked as next. Or rather, it was, but it would only ever mark the next Part if the Rundown has an ActiveCursor. Since this bug appears when the Server is restarted _before_ the first Take, there was no ActiveCursor and the Rundown would never mark the next Part as next.
To fix this, when an already active Rundown is instantiated, it now also marks the next Part as next.