### PR TITLE
SOF-1910 Return empty list if we don't have any sources configured

### DIFF
--- a/src/blueprints/tv2/helpers/tv2-studio-blueprint-configuration-mapper.ts
+++ b/src/blueprints/tv2/helpers/tv2-studio-blueprint-configuration-mapper.ts
@@ -143,7 +143,10 @@ export class Tv2StudioBlueprintConfigurationMapper {
     }
   }
 
-  private mapSourcesWithSound(sources: CoreSourceMappingWithSound[]): Tv2SourceMappingWithSound[] {
+  private mapSourcesWithSound(sources: CoreSourceMappingWithSound[] | undefined): Tv2SourceMappingWithSound[] {
+    if (!sources) {
+      return []
+    }
     return sources.map(source => {
       return {
         id: source._id,


### PR DESCRIPTION
Guard agains that a source* mapping might not have been configured.

*Cameras, Lives, Feeds, Replays etc.