### PR TITLE
SOF-1913 Expose rank on Actions. Map rank from ActionManifest to Actions

### DIFF
--- a/src/blueprints/tv2/action-factories/tv2-audio-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-audio-action-factory.ts
@@ -69,6 +69,7 @@ export class Tv2AudioActionFactory {
     return {
       id: 'fadePersistedAudioAction',
       name: 'Fade Persisted Audio',
+      rank: 0,
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
         pieceInterface
@@ -102,6 +103,7 @@ export class Tv2AudioActionFactory {
     return {
       id: 'studioMicrophonesUpAction',
       name: 'Studio Microphones Up',
+      rank: 0,
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
         pieceInterface
@@ -145,6 +147,7 @@ export class Tv2AudioActionFactory {
     return {
       id: 'studioMicrophonesDownAction',
       name: 'Studio Microphones Down',
+      rank: 0,
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
         pieceInterface
@@ -168,6 +171,7 @@ export class Tv2AudioActionFactory {
     return {
       id: 'stopAudioBedAction',
       name: 'Stop audio bed',
+      rank: 0,
       description: 'Stops audio bed.',
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
@@ -209,6 +213,7 @@ export class Tv2AudioActionFactory {
     return {
       id: 'fadeAudioBedAction',
       name: 'Fade Audio bed',
+      rank: 0,
       description: 'Fades the Audio bed',
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
@@ -260,6 +265,7 @@ export class Tv2AudioActionFactory {
     return {
       id: 'resynchronizeAudioAction',
       name: 'Resynchronize Audio',
+      rank: 0,
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
         pieceInterface

--- a/src/blueprints/tv2/action-factories/tv2-camera-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-camera-action-factory.ts
@@ -42,6 +42,7 @@ export class Tv2CameraActionFactory {
     return {
       id: `cameraAsNextAction_${cameraSource.id}`,
       name: `KAM ${cameraSource.name} PVW`,
+      rank: 0,
       description: `Insert Camera ${cameraSource.name} as next.`,
       type: PartActionType.INSERT_PART_AS_NEXT,
       data: {
@@ -127,6 +128,7 @@ export class Tv2CameraActionFactory {
     return {
       id: `cameraAsOnAirAction_${cameraSource.id}`,
       name: `KAM ${cameraSource.name}`,
+      rank: 0,
       description: `Insert and Take Camera ${cameraSource.name}.`,
       type: PartActionType.INSERT_PART_AS_ON_AIR,
       data: {

--- a/src/blueprints/tv2/action-factories/tv2-graphics-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-graphics-action-factory.ts
@@ -95,6 +95,7 @@ export class Tv2GraphicsActionFactory {
     return {
       id: 'themeOutAction',
       name: 'Theme out',
+      rank: 0,
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
         pieceInterface
@@ -138,6 +139,7 @@ export class Tv2GraphicsActionFactory {
     return {
       id: 'overlayInitializeAction',
       name: 'Overlay initialize',
+      rank: 0,
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
         pieceInterface
@@ -159,6 +161,7 @@ export class Tv2GraphicsActionFactory {
     return {
       id: 'continueGraphicsAction',
       name: 'Gfx continue',
+      rank: 0,
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
         pieceInterface
@@ -181,6 +184,7 @@ export class Tv2GraphicsActionFactory {
     return {
       id: 'clearGraphicsAction',
       name: 'Gfx Clear',
+      rank: 0,
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
         pieceInterface,
@@ -206,6 +210,7 @@ export class Tv2GraphicsActionFactory {
     return {
       id: 'allOutGraphicsAction',
       name: 'Gfx All Out',
+      rank: 0,
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
         pieceInterface,
@@ -226,6 +231,7 @@ export class Tv2GraphicsActionFactory {
         id: `fullscreen_graphics_${this.stringHashConverter.getHashedValue(graphicsData.name)}`,
         rundownId: graphicsData.rundownId,
         name: `Fullscreen Graphics - ${graphicsData.name}`,
+        rank: graphicsData.rank,
         type: PartActionType.INSERT_PART_AS_NEXT,
         data: {
           partInterface: partInterface,
@@ -390,6 +396,7 @@ export class Tv2GraphicsActionFactory {
     return {
       id: `ident_${this.stringHashConverter.getHashedValue(overlayGraphicsData.name)}`,
       name: overlayGraphicsData.name,
+      rank: overlayGraphicsData.rank,
       rundownId: overlayGraphicsData.rundownId,
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
@@ -427,6 +434,7 @@ export class Tv2GraphicsActionFactory {
     return {
       id: `lower_third_${this.stringHashConverter.getHashedValue(overlayGraphicsData.name)}`,
       name: overlayGraphicsData.name,
+      rank: overlayGraphicsData.rank,
       rundownId: overlayGraphicsData.rundownId,
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {

--- a/src/blueprints/tv2/action-factories/tv2-remote-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-remote-action-factory.ts
@@ -69,6 +69,7 @@ export class Tv2RemoteActionFactory {
     return {
       id: `remoteAsNextAction_${remoteSource.name}`.replaceAll(' ', ''),
       name: `LIVE ${remoteSource.name}`,
+      rank: 0,
       description: `Insert LIVE ${remoteSource.name} as next.`,
       type: PartActionType.INSERT_PART_AS_NEXT,
       data: {
@@ -153,6 +154,7 @@ export class Tv2RemoteActionFactory {
     return {
       id: 'recall_last_planned_remote_as_next_action',
       name: 'Recall last Live',
+      rank: 0,
       description: 'Recalls the last live that has been on air.',
       type: PartActionType.INSERT_PART_AS_NEXT,
       metadata: {

--- a/src/blueprints/tv2/action-factories/tv2-replay-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-replay-action-factory.ts
@@ -55,6 +55,7 @@ export class Tv2ReplayActionFactory {
     return {
       id: `insert_${sanitizedName}_VO_as_next_part_action`,
       name: `${source.name} VO`,
+      rank: 0,
       description: '',
       type: PartActionType.INSERT_PART_AS_NEXT,
       data: {
@@ -82,6 +83,7 @@ export class Tv2ReplayActionFactory {
     return {
       id: `insert_${sanitizedName}_as_next_part_action`,
       name: source.name,
+      rank: 0,
       description: '',
       type: PartActionType.INSERT_PART_AS_NEXT,
       data: {
@@ -163,6 +165,7 @@ export class Tv2ReplayActionFactory {
     return {
       id: `insert_studio_aux_${sanitizedName}_action`,
       name: `${source.name} Studio AUX`,
+      rank: 0,
       description: '',
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
@@ -205,6 +208,7 @@ export class Tv2ReplayActionFactory {
     return {
       id: `insert_viz_aux_${sanitizedName}_action`,
       name: `${source.name} Viz AUX`,
+      rank: 0,
       description: '',
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {

--- a/src/blueprints/tv2/action-factories/tv2-robot-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-robot-action-factory.ts
@@ -34,6 +34,7 @@ export class Tv2RobotActionFactory {
     return {
       id: 'callRobotPresetAction',
       name: 'Robot Preset',
+      rank: 0,
       description: 'Calls the preset parsed as the argument',
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {

--- a/src/blueprints/tv2/action-factories/tv2-split-screen-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-split-screen-action-factory.ts
@@ -172,6 +172,7 @@ export class Tv2SplitScreenActionFactory {
       return {
         id: `splitScreenLayoutAsNextAction_${splitScreenConfiguration.name}`,
         name: splitScreenConfiguration.name,
+        rank: 0,
         description: '',
         type: PartActionType.INSERT_PART_AS_NEXT,
         data: {
@@ -255,6 +256,7 @@ export class Tv2SplitScreenActionFactory {
           return {
             id: `insert_${this.replaceWhiteSpaceWithUnderscore(name)}_${this.replaceWhiteSpaceWithUnderscore(source.name)}_to_split_screen_input_${this.createDisplayIndex(inputIndex)}_action`,
             name: `Insert ${name} ${source.name} in DVE input ${this.createDisplayIndex(inputIndex)}`,
+            rank: 0,
             description: `Insert ${name} ${source.name} in DVE input ${this.createDisplayIndex(inputIndex)}`,
             type: PieceActionType.REPLACE_PIECE,
             data: {
@@ -404,6 +406,7 @@ export class Tv2SplitScreenActionFactory {
       return {
         id: `plannedSplitScreenAsNextAction_${data.name.replace(/\s/g, '')}`,
         name: data.template,
+        rank: data.rank,
         rundownId: data.rundownId,
         description: '',
         type: PartActionType.INSERT_PART_AS_NEXT,
@@ -439,6 +442,7 @@ export class Tv2SplitScreenActionFactory {
     return {
       id: 'recall_last_split_screen_action',
       name: 'Recall DVE',
+      rank: 0,
       description: 'Recalls the last planned DVE that has been on Air',
       type: PartActionType.INSERT_PART_AS_NEXT,
       metadata: {
@@ -540,6 +544,7 @@ export class Tv2SplitScreenActionFactory {
     return {
       id: `insert_last_video_clip_to_split_screen_input_${this.createDisplayIndex(inputIndex)}${audioMode === Tv2AudioMode.VOICE_OVER ? '_vo' : ''}_action`,
       name: `Insert last Video ${audioMode === Tv2AudioMode.VOICE_OVER ? 'Voice Over ' : ''}Clip in DVE input ${this.createDisplayIndex(inputIndex)}`,
+      rank: 0,
       description: `Insert last Video Clip in DVE input ${this.createDisplayIndex(inputIndex)}`,
       type: PieceActionType.REPLACE_PIECE,
       metadata: {
@@ -605,6 +610,7 @@ export class Tv2SplitScreenActionFactory {
 
     const videoClipData: Tv2VideoClipManifestData = {
       name: '',
+      rank: 0,
       fileName: fileContent.fileName,
       durationFromIngest: 0,
       adLibPix: audioMode === Tv2AudioMode.VOICE_OVER,

--- a/src/blueprints/tv2/action-factories/tv2-transition-effect-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-transition-effect-action-factory.ts
@@ -178,6 +178,7 @@ export class Tv2TransitionEffectActionFactory {
     return {
       id: `${effectName}_transition_action_${actionType.toString()}`,
       name: this.mapToTransitionEffectNameForActionType(actionType, effectName),
+      rank: 0,
       description: this.mapToTransitionEffectDescriptionForActionType(actionType, effectName),
       type: actionType,
       data: {
@@ -240,6 +241,7 @@ export class Tv2TransitionEffectActionFactory {
     return {
       id: `mix_transition_action_${actionType.toString()}`,
       name: this.mapToTransitionEffectNameForActionType(actionType, SpecialEffectName.MIX),
+      rank: 0,
       description: this.mapToTransitionEffectDescriptionForActionType(actionType, SpecialEffectName.MIX),
       type: actionType,
       data: {
@@ -268,6 +270,7 @@ export class Tv2TransitionEffectActionFactory {
     return {
       id: `dip_transition_action_${actionType.toString()}`,
       name: this.mapToTransitionEffectNameForActionType(actionType, SpecialEffectName.DIP),
+      rank: 0,
       description: this.mapToTransitionEffectDescriptionForActionType(actionType, SpecialEffectName.DIP),
       type: actionType,
       data: {

--- a/src/blueprints/tv2/action-factories/tv2-video-clip-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-video-clip-action-factory.ts
@@ -86,6 +86,7 @@ export class Tv2VideoClipActionFactory {
     return {
       id: `videoClipAsNextAction_${videoClipData.name}_${videoClipData.fileName}`, // TODO: Utilize information about the Segment once we control ingest
       name: videoClipData.name,
+      rank: videoClipData.rank,
       rundownId: videoClipData.rundownId,
       type: PartActionType.INSERT_PART_AS_NEXT,
       data: {

--- a/src/blueprints/tv2/action-factories/tv2-video-mixer-configuration-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-video-mixer-configuration-action-factory.ts
@@ -42,6 +42,7 @@ export class Tv2VideoMixerConfigurationActionFactory {
     return {
       id: `downstreamKeyer${downstreamKeyerNumber}${actionName}Action`,
       name: `Downstream Keyer ${downstreamKeyerNumber} ${actionName}`,
+      rank: 0,
       type: PieceActionType.INSERT_PIECE_AS_ON_AIR,
       data: {
         pieceInterface

--- a/src/blueprints/tv2/helpers/tv2-action-manifest-mapper.ts
+++ b/src/blueprints/tv2/helpers/tv2-action-manifest-mapper.ts
@@ -32,10 +32,11 @@ export class Tv2ActionManifestMapper {
         const data: Tv2ActionManifestSplitScreenData = actionManifest.data
         const sources: Map<SplitScreenBoxInput, Tv2SourceMappingWithSound> = this.getSplitScreenSourcesFromActionManifestData(data, blueprintConfiguration)
         return {
-          name: data.name,
+          name: data.userData.name,
+          rank: data.rank,
           rundownId: actionManifest.rundownId,
-          template: data.config.template,
-          locatorLabels: data.config.labels,
+          template: data.userData.config.template,
+          locatorLabels: data.userData.config.labels,
           sources
         }
       })
@@ -43,17 +44,17 @@ export class Tv2ActionManifestMapper {
 
   private getSplitScreenSourcesFromActionManifestData(data: Tv2ActionManifestSplitScreenData, blueprintConfiguration: Tv2BlueprintConfiguration): Map<SplitScreenBoxInput, Tv2SourceMappingWithSound> {
     const sources: Map<SplitScreenBoxInput, Tv2SourceMappingWithSound> = new Map()
-    if (data.config.sources.INP1) {
-      sources.set(SplitScreenBoxInput.INPUT_1, this.mapActionManifestSplitScreenSourceToSource(blueprintConfiguration, data.config.sources.INP1))
+    if (data.userData.config.sources.INP1) {
+      sources.set(SplitScreenBoxInput.INPUT_1, this.mapActionManifestSplitScreenSourceToSource(blueprintConfiguration, data.userData.config.sources.INP1))
     }
-    if (data.config.sources.INP2) {
-      sources.set(SplitScreenBoxInput.INPUT_2, this.mapActionManifestSplitScreenSourceToSource(blueprintConfiguration, data.config.sources.INP2))
+    if (data.userData.config.sources.INP2) {
+      sources.set(SplitScreenBoxInput.INPUT_2, this.mapActionManifestSplitScreenSourceToSource(blueprintConfiguration, data.userData.config.sources.INP2))
     }
-    if (data.config.sources.INP3) {
-      sources.set(SplitScreenBoxInput.INPUT_3, this.mapActionManifestSplitScreenSourceToSource(blueprintConfiguration, data.config.sources.INP3))
+    if (data.userData.config.sources.INP3) {
+      sources.set(SplitScreenBoxInput.INPUT_3, this.mapActionManifestSplitScreenSourceToSource(blueprintConfiguration, data.userData.config.sources.INP3))
     }
-    if (data.config.sources.INP4) {
-      sources.set(SplitScreenBoxInput.INPUT_4, this.mapActionManifestSplitScreenSourceToSource(blueprintConfiguration, data.config.sources.INP4))
+    if (data.userData.config.sources.INP4) {
+      sources.set(SplitScreenBoxInput.INPUT_4, this.mapActionManifestSplitScreenSourceToSource(blueprintConfiguration, data.userData.config.sources.INP4))
     }
     return sources
   }
@@ -83,11 +84,12 @@ export class Tv2ActionManifestMapper {
       .map(actionManifest => {
         const data: Tv2ActionManifestVideoClipData = actionManifest.data
         return {
-          name: data.partDefinition.storyName,
-          fileName: data.partDefinition.fields.videoId,
-          durationFromIngest: data.duration,
-          adLibPix: data.adLibPix,
-          audioMode: data.voLevels ? Tv2AudioMode.VOICE_OVER : Tv2AudioMode.FULL,
+          name: data.userData.partDefinition.storyName,
+          rank: data.rank,
+          fileName: data.userData.partDefinition.fields.videoId,
+          durationFromIngest: data.userData.duration,
+          adLibPix: data.userData.adLibPix,
+          audioMode: data.userData.voLevels ? Tv2AudioMode.VOICE_OVER : Tv2AudioMode.FULL,
           rundownId: actionManifest.rundownId
         }
       })
@@ -99,9 +101,10 @@ export class Tv2ActionManifestMapper {
       .map(actionManifest => {
         const data: Tv2ActionManifestFullscreenGraphicsData = actionManifest.data
         return {
-          name: data.name,
+          name: data.userData.name,
+          rank: data.rank,
           rundownId: actionManifest.rundownId,
-          vcpId: data.vcpid
+          vcpId: data.userData.vcpid
         }
       })
   }
@@ -113,6 +116,7 @@ export class Tv2ActionManifestMapper {
         const data: Tv2ActionManifestOverlayGraphicsData = actionManifest.data
         return {
           name: data.name,
+          rank: data.rank,
           rundownId: actionManifest.rundownId,
           sourceLayerId: data.sourceLayerId,
           templateName: this.getTemplateName(data.name),

--- a/src/blueprints/tv2/value-objects/tv2-action-manifest-data.ts
+++ b/src/blueprints/tv2/value-objects/tv2-action-manifest-data.ts
@@ -8,47 +8,56 @@ export type Tv2ActionManifestData = Tv2ActionManifestVideoClipData
 | Tv2ActionManifestFullscreenGraphicsData
 | Tv2ActionManifestOverlayGraphicsData
 /**
- * This corresponds to the 'userData' field on the 'adLibActions' collection in the database when dealing with Video Clips.
+ * The 'userData' field corresponds to the 'userData' field on the 'adLibActions' collection in the database when dealing with Video Clips.
  * The attributes need to match the attributes in the database
  */
 export interface Tv2ActionManifestVideoClipData {
-  adLibPix: boolean
-  voLevels: boolean
-  duration: number
-  partDefinition: {
-    storyName: string
-    fields: {
-      videoId: string
+  rank: number
+  userData: {
+    adLibPix: boolean
+    voLevels: boolean
+    duration: number
+    partDefinition: {
+      storyName: string
+      fields: {
+        videoId: string
+      }
     }
   }
 }
 
 /**
- * This corresponds to the 'userData' field on the 'adLibActions' collection in the database when dealing with split screens.
+ * The 'userData' field corresponds to the 'userData' field on the 'adLibActions' collection in the database when dealing with split screens.
  * The attributes need to match the attributes in the database.
  */
 export interface Tv2ActionManifestSplitScreenData {
-  name: string
-  pieceType: Tv2PieceType
-  config: {
-    template: string
-    labels: string[]
-    sources: {
-      [SplitScreenBoxInput.INPUT_1]?: Tv2ActionManifestSplitScreenSource,
-      [SplitScreenBoxInput.INPUT_2]?: Tv2ActionManifestSplitScreenSource,
-      [SplitScreenBoxInput.INPUT_3]?: Tv2ActionManifestSplitScreenSource,
-      [SplitScreenBoxInput.INPUT_4]?: Tv2ActionManifestSplitScreenSource,
+  rank: number
+  userData: {
+    name: string
+    pieceType: Tv2PieceType
+    config: {
+      template: string
+      labels: string[]
+      sources: {
+        [SplitScreenBoxInput.INPUT_1]?: Tv2ActionManifestSplitScreenSource,
+        [SplitScreenBoxInput.INPUT_2]?: Tv2ActionManifestSplitScreenSource,
+        [SplitScreenBoxInput.INPUT_3]?: Tv2ActionManifestSplitScreenSource,
+        [SplitScreenBoxInput.INPUT_4]?: Tv2ActionManifestSplitScreenSource,
+      }
     }
   }
 }
 
 /**
- * This corresponds to the 'userData' field on the 'adLibActions' collection in the database when dealing with Fullscreen Graphics.
+ * The 'userData' field corresponds to the 'userData' field on the 'adLibActions' collection in the database when dealing with Fullscreen Graphics.
  * The attributes need to match the attributes in the database.
  */
 export interface Tv2ActionManifestFullscreenGraphicsData {
-  vcpid: number
-  name: string,
+  rank: number
+  userData: {
+    vcpid: number
+    name: string
+  }
 }
 
 /**
@@ -56,6 +65,7 @@ export interface Tv2ActionManifestFullscreenGraphicsData {
  * The attributes need to match the attributes in the database.
  */
 export interface Tv2ActionManifestOverlayGraphicsData {
+  rank: number
   sourceLayerId: Tv2SourceLayer
   name: string,
   expectedDuration?: number
@@ -81,6 +91,7 @@ export enum TvActionManifestSplitScreenSourceType {
 
 export interface Tv2VideoClipManifestData {
   name: string // userData.partDefinition.storyName
+  rank: number
   fileName: string // userData.partDefinition.videoId
   durationFromIngest: number // userData.duration
   adLibPix: boolean // userData.adLibPix // What does "adLibPix" mean?
@@ -91,6 +102,7 @@ export interface Tv2VideoClipManifestData {
 export interface Tv2SplitScreenManifestData {
   rundownId: string
   name: string
+  rank: number
   template: string
   locatorLabels: string[]
   sources: Map<SplitScreenBoxInput, Tv2SourceMappingWithSound>
@@ -100,12 +112,14 @@ export interface Tv2FullscreenGraphicsManifestData {
   rundownId: string
   vcpId: number
   name: string
+  rank: number
 }
 
 export interface Tv2OverlayGraphicsManifestData {
   rundownId: string
   sourceLayerId: Tv2SourceLayer
   name: string
+  rank: number
   templateName: string
   displayText: string
   expectedDuration?: number

--- a/src/business-logic/services/test/execute-action-service.spec.ts
+++ b/src/business-logic/services/test/execute-action-service.spec.ts
@@ -358,6 +358,7 @@ function createPartAction(actionType: PartActionType): PartAction {
   return {
     id: 'actionId',
     name: 'someAction',
+    rank: 0,
     type: actionType,
     data: {
       partInterface: {
@@ -372,6 +373,7 @@ function createPieceAction(actionType: PieceActionType): PieceAction {
   return {
     id: 'actionId',
     name: 'someAction',
+    rank: 0,
     type: actionType,
     data: {
       pieceInterface: {

--- a/src/data-access/repositories/mongo/mongo-ad-lib-actions-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-ad-lib-actions-repository.ts
@@ -5,10 +5,13 @@ import { BaseMongoRepository } from './base-mongo-repository'
 
 const AD_LIB_ACTIONS_COLLECTION: string = 'adLibActions'
 
-interface AdLibAction {
+interface MongoAdLibAction {
   actionId: string
   rundownId: string
   userData: unknown
+  display: {
+    _rank: number
+  }
 }
 
 export class MongoAdLibActionsRepository extends BaseMongoRepository implements ActionManifestRepository {
@@ -23,15 +26,18 @@ export class MongoAdLibActionsRepository extends BaseMongoRepository implements 
 
   public async getActionManifests(rundownId: string): Promise<ActionManifest[]> {
     this.assertDatabaseConnection(this.getActionManifests.name)
-    const adLibActions: AdLibAction[] = await this.getCollection().find<AdLibAction>({ rundownId }).toArray()
+    const adLibActions: MongoAdLibAction[] = await this.getCollection().find<MongoAdLibAction>({ rundownId }).toArray()
     return adLibActions.map(adLibAction => this.mapToActionManifest(adLibAction))
   }
 
-  private mapToActionManifest(adLibAction: AdLibAction): ActionManifest {
+  private mapToActionManifest(adLibAction: MongoAdLibAction): ActionManifest {
     return {
       actionId: adLibAction.actionId,
       rundownId: adLibAction.rundownId,
-      data: adLibAction.userData
+      data: {
+        rank: adLibAction.display._rank,
+        userData: adLibAction.userData
+      }
     }
   }
 }

--- a/src/data-access/repositories/mongo/mongo-ad-lib-piece-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-ad-lib-piece-repository.ts
@@ -7,10 +7,11 @@ import { MongoId } from './mongo-entity-converter'
 
 const AD_LIB_PIECES_COLLECTION: string = 'adLibPieces'
 
-interface AdLibPiece {
+interface MongoAdLibPiece {
   sourceLayerId: string
   rundownId: string
   name: string
+  _rank: number
   expectedDuration: number | null
 }
 
@@ -26,7 +27,7 @@ export class MongoAdLibPieceRepository extends BaseMongoRepository implements Ac
 
   public async getActionManifests(rundownId: string): Promise<ActionManifest[]> {
     this.assertDatabaseConnection(this.getActionManifests.name)
-    const mongoAdLibPieces: AdLibPiece[] = await this.getCollection().find<AdLibPiece>({
+    const mongoAdLibPieces: MongoAdLibPiece[] = await this.getCollection().find<MongoAdLibPiece>({
       rundownId: rundownId,
       ...this.filterOutCommentatorManifests()
     }).toArray()
@@ -38,12 +39,13 @@ export class MongoAdLibPieceRepository extends BaseMongoRepository implements Ac
     return { uniquenessId: { $not: { $regex: '.*_commentator$' } } }
   }
 
-  private mapToActionManifest(adLibPiece: AdLibPiece): ActionManifest {
+  private mapToActionManifest(adLibPiece: MongoAdLibPiece): ActionManifest {
     return {
       actionId: adLibPiece.sourceLayerId,
       rundownId: adLibPiece.rundownId,
       data: {
         name: adLibPiece.name,
+        rank: adLibPiece._rank,
         expectedDuration: adLibPiece.expectedDuration ?? undefined,
         sourceLayerId: adLibPiece.sourceLayerId
       },

--- a/src/model/entities/action.ts
+++ b/src/model/entities/action.ts
@@ -7,6 +7,7 @@ import { InTransition } from '../value-objects/in-transition'
 export interface Action {
   id: string
   name: string
+  rank: number
   description?: string
   type: ActionType
   data: unknown

--- a/src/presentation/dtos/action-dto.ts
+++ b/src/presentation/dtos/action-dto.ts
@@ -5,6 +5,7 @@ export class ActionDto {
 
   public readonly id: string
   public readonly name: string
+  public readonly rank: number
   public readonly description?: string
   public readonly type: ActionType
   public readonly metadata?: unknown
@@ -14,6 +15,7 @@ export class ActionDto {
   constructor(action: Action) {
     this.id = action.id
     this.name = action.name
+    this.rank = action.rank
     this.description = action.description
     this.type = action.type
     this.metadata = action.metadata


### PR DESCRIPTION
Actions now have a `rank` attribute.
Right now, all Actions have rank zero except for our Rundown Actions. The Rundown Actions gets their rank from the ActionManifests.

Note: In order for the ActionManifests to have a rank other than zero, this PR needs to be merged to Blueprints: https://github.com/tv2/sofie-blueprints-inews/pull/239