### PR TITLE
SOF-1908/ Add segment numbers to segment

### DIFF
--- a/src/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/src/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -67,6 +67,7 @@ export interface MongoSegment extends MongoId {
   isOnAir: boolean
   isNext: boolean
   isUnsynced: boolean
+  referenceTag?: string
   budgetDuration?: number
   executedAtEpochTime?: number
 }
@@ -291,6 +292,7 @@ export class MongoEntityConverter {
       rundownId: segment.rundownId,
       name: segment.name,
       rank: segment.rank,
+      referenceTag: segment.referenceTag,
       isHidden: segment.isHidden,
       metadata: segment.metadata,
       partIds: segment.getParts().map(part => part.id),

--- a/src/data-access/repositories/mongo/mongo-ingested-entity-converter.ts
+++ b/src/data-access/repositories/mongo/mongo-ingested-entity-converter.ts
@@ -54,6 +54,7 @@ export interface MongoIngestedSegment extends MongoId {
   rundownId: string
   externalId: string
   isHidden: boolean
+  identifier?: string
   metaData?: unknown // This is the current spelling in the database from Core... TOD: Update when we control Ingest
   budgetDuration?: number
 }
@@ -161,6 +162,7 @@ export class MongoIngestedEntityConverter {
       name: mongoSegment.name,
       rank: mongoSegment._rank,
       isHidden: mongoSegment.isHidden,
+      referenceTag: mongoSegment.identifier,
       metadata: mongoSegment.metaData,
       ingestedParts: [],
       budgetDuration: mongoSegment.budgetDuration ?? undefined

--- a/src/model/entities/ingested-segment.ts
+++ b/src/model/entities/ingested-segment.ts
@@ -6,6 +6,7 @@ export interface IngestedSegment {
   readonly name: string
   readonly rank: number
   readonly isHidden: boolean
+  readonly referenceTag?: string
   readonly metadata?: unknown
   readonly budgetDuration?: number
   readonly ingestedParts: Readonly<IngestedPart[]>

--- a/src/model/entities/segment.ts
+++ b/src/model/entities/segment.ts
@@ -12,6 +12,7 @@ export interface SegmentInterface {
   name: string
   rank: number
   isHidden: boolean
+  referenceTag?: string
   metadata?: unknown
   parts: Part[]
   isOnAir: boolean
@@ -27,6 +28,7 @@ export class Segment {
   public readonly name: string
   public readonly expectedDurationInMs?: number
   public readonly isHidden: boolean
+  public readonly referenceTag?: string
   public readonly metadata?: unknown
   public rank: number
 
@@ -43,6 +45,7 @@ export class Segment {
     this.name = segment.name
     this.rank = segment.rank
     this.isHidden = segment.isHidden
+    this.referenceTag = segment.referenceTag
     this.metadata = segment.metadata
     this.isSegmentOnAir = segment.isOnAir
     this.isSegmentNext = segment.isNext

--- a/src/presentation/dtos/segment-dto.ts
+++ b/src/presentation/dtos/segment-dto.ts
@@ -11,6 +11,7 @@ export class SegmentDto {
   public readonly isUnsynced: boolean
   public readonly rank: number
   public readonly isHidden: boolean
+  public readonly referenceTag?: string
   public readonly metadata?: unknown
   public readonly expectedDurationInMs?: number
   public readonly executedAtEpochTime?: number
@@ -26,6 +27,7 @@ export class SegmentDto {
     this.isUnsynced = segment.isUnsynced()
     this.rank = segment.rank
     this.isHidden = segment.isHidden
+    this.referenceTag = segment.referenceTag
     this.metadata = segment.metadata
     this.expectedDurationInMs = segment.expectedDurationInMs
     this.executedAtEpochTime = segment.getExecutedAtEpochTime()


### PR DESCRIPTION
The `identifier` that we set in blueprints is how producers sometimes reference the segments they are using. This field is mapped to the property called `referenceTag` and is put on segments so we can expose it to the frontend.