### PR TITLE
SOF-1953 Also emit 'system' Actions on Ingest

### DIFF
--- a/src/business-logic/services/ingest-data-changed-service.ts
+++ b/src/business-logic/services/ingest-data-changed-service.ts
@@ -308,6 +308,7 @@ export class IngestDataChangedService implements DataChangeService {
         this.rundownIdsToGenerateActionsFor.delete(rundownId)
       })
     )
+    await this.generateActionsForSystem()
   }
 
   private async generateActionsForRundown(rundownId: string): Promise<void> {
@@ -317,6 +318,14 @@ export class IngestDataChangedService implements DataChangeService {
     this.actionEventEmitter.emitActionsUpdatedEvent(actions, rundownId)
 
     await this.actionRepository.deleteActionsForRundown(rundownId)
+    await this.actionRepository.saveActions(actions)
+  }
+
+  private async generateActionsForSystem(): Promise<void> {
+    const configuration: Configuration = await this.configurationRepository.getConfiguration()
+    const actions: Action[] = this.blueprint.generateActions(configuration, [])
+    this.actionEventEmitter.emitActionsUpdatedEvent(actions)
+
     await this.actionRepository.saveActions(actions)
   }
 

--- a/src/presentation/services/event-builder.ts
+++ b/src/presentation/services/event-builder.ts
@@ -343,8 +343,8 @@ export class EventBuilder implements RundownEventBuilder, ActionEventBuilder, Ac
     return {
       type: ActionEventType.ACTIONS_UPDATED,
       timestamp: Date.now(),
-      actions: actions.map(action => new ActionDto(action)),
-      rundownId
+      rundownId,
+      actions: actions.map(action => new ActionDto(action))
     }
   }
 }


### PR DESCRIPTION
We were only emitting "Rundown" Actions (which technically also has the SystemActions), but our emits was always in the context of a Rundown. Now we also emit only the "system" Actions so that frontends can keep their Actions without a Rundown updated.

Also move the "position" of the `rundownId` in the event, so you don't have to scroll past all the Actions to see if there is a rundownId.