### PR TITLE
Sof 1999/unplanned parts becomes unplanned on server restart

### DIFF
--- a/src/model/entities/part.ts
+++ b/src/model/entities/part.ts
@@ -139,6 +139,9 @@ export class Part {
   }
 
   public markAsUnsynced(): void {
+    if (!this.isPlanned) {
+      return // Only planned Parts can be unsynced
+    }
     this.isPartUnsynced = true
     this.rank = this.rank - 1
     this.pieces.forEach(piece => piece.markAsUnsyncedWithUnsyncedPart())

--- a/src/model/entities/part.ts
+++ b/src/model/entities/part.ts
@@ -235,6 +235,10 @@ export class Part {
     return this.rank
   }
 
+  public updateRank(rank: number): void {
+    this.rank = rank
+  }
+
   public setSegmentId(segmentId: string): void {
     if (this.isPlanned) {
       throw new UnsupportedOperationException(`Can't update SegmentId for Part: ${this.id}. Only unplanned Parts are allowed to have their Segment id updated!`)

--- a/src/model/entities/rundown.ts
+++ b/src/model/entities/rundown.ts
@@ -701,8 +701,24 @@ export class Rundown extends BasicRundown {
     this.assertActive(this.insertPartAsNext.name)
     this.assertNotUndefined(this.activeCursor, 'active Segment')
 
+    this.updateRankFromOnAirAndNextParts(part)
     this.activeCursor.segment.insertPartAfterActivePart(part)
     this.setNext(this.activeCursor.segment.id, part.id)
+  }
+
+  private updateRankFromOnAirAndNextParts(partToBeUpdated: Part): void {
+    const onAirRank: number = this.activeCursor?.part.getRank() ?? 0
+    const nextRank: number = this.nextCursor?.part.getRank() ?? 0
+
+    if (this.activeCursor?.segment.id !== this.nextCursor?.segment.id) {
+      // The new rank is onAir Parts rank times 1.5
+      partToBeUpdated.updateRank(onAirRank * 1.5)
+      return
+    }
+
+    // The new rank is half the 'distance' between the onAir and next Parts plus the rank of the onAir Part.
+    const newRank: number = (nextRank - onAirRank) / 2 + onAirRank
+    partToBeUpdated.updateRank(newRank)
   }
 
   public stopActivePiecesOnLayers(layers: string[]): void {

--- a/src/model/entities/rundown.ts
+++ b/src/model/entities/rundown.ts
@@ -701,12 +701,12 @@ export class Rundown extends BasicRundown {
     this.assertActive(this.insertPartAsNext.name)
     this.assertNotUndefined(this.activeCursor, 'active Segment')
 
-    this.updateRankFromOnAirAndNextParts(part)
+    this.updateRankFromOnAirPart(part)
     this.activeCursor.segment.insertPartAfterActivePart(part)
     this.setNext(this.activeCursor.segment.id, part.id)
   }
 
-  private updateRankFromOnAirAndNextParts(partToBeUpdated: Part): void {
+  private updateRankFromOnAirPart(partToBeUpdated: Part): void {
     if (!this.activeCursor) {
       return
     }

--- a/src/model/entities/rundown.ts
+++ b/src/model/entities/rundown.ts
@@ -722,7 +722,7 @@ export class Rundown extends BasicRundown {
       if (!(error instanceof LastPartInSegmentException)) {
         throw error
       }
-      partToBeUpdated.updateRank(onAirPart.getRank() + 0.1)
+      partToBeUpdated.updateRank(onAirPart.getRank() + 1)
     }
   }
 

--- a/src/model/entities/test/part.spec.ts
+++ b/src/model/entities/test/part.spec.ts
@@ -2277,61 +2277,78 @@ describe(Part.name, () => {
   })
 
   describe(Part.prototype.markAsUnsynced.name, () => {
-    it('marks the Part as unsynced',() => {
-      const testee: Part = new Part({ isUnsynced: false, segmentId: 'someSegmentId' } as PartInterface)
-      expect(testee.isUnsynced()).toBeFalsy()
-      testee.markAsUnsynced()
-      expect(testee.isUnsynced()).toBeTruthy()
-    })
-
-    it('sets the rank to one lower than the original rank', () => {
-      const rank: number = 500
-      const testee: Part = new Part({ rank, segmentId: 'someSegmentId' } as PartInterface)
-      testee.markAsUnsynced()
-      expect(testee.getRank()).toBe(rank - 1)
-    })
-
-    describe('segment id already have the unsynced postfix', () => {
-      it('does not add an extra postfix', () => {
-        const segmentIdWithPostfix: string = `someSegmentId${UNSYNCED_ID_POSTFIX}`
-        const testee: Part = new Part({ segmentId: segmentIdWithPostfix } as PartInterface)
+    describe('the Part is not planned', () => {
+      it('is not marked as unsynced', () => {
+        // A Part is planned if it has an "ingestedPart"
+        const testee: Part = new Part({ isUnsynced: false, ingestedPart: undefined } as PartInterface)
+        expect(testee.isUnsynced()).toBeFalsy()
         testee.markAsUnsynced()
-        expect(testee.getSegmentId()).toBe(segmentIdWithPostfix)
+        expect(testee.isUnsynced()).toBeFalsy()
       })
     })
 
-    it('marks all its Pieces as unsynced', () => {
-      const pieceOne: Piece = EntityMockFactory.createPieceMock({ id: '1' } as PieceInterface)
-      const pieceTwo: Piece = EntityMockFactory.createPieceMock({ id: '2' } as PieceInterface)
-      const pieceThree: Piece = EntityMockFactory.createPieceMock({ id: '3' } as PieceInterface)
+    describe('the Part is planned', () => {
+      it('marks the Part as unsynced',() => {
+        const ingestedPart: IngestedPart = {} as IngestedPart
+        const testee: Part = new Part({ isUnsynced: false, ingestedPart,  segmentId: 'someSegmentId' } as PartInterface)
+        expect(testee.isUnsynced()).toBeFalsy()
+        testee.markAsUnsynced()
+        expect(testee.isUnsynced()).toBeTruthy()
+      })
 
-      const pieces: Piece[] = [
-        instance(pieceOne),
-        instance(pieceTwo),
-        instance(pieceThree)
-      ]
+      it('sets the rank to one lower than the original rank', () => {
+        const ingestedPart: IngestedPart = {} as IngestedPart
+        const rank: number = 500
+        const testee: Part = new Part({ rank, ingestedPart, segmentId: 'someSegmentId' } as PartInterface)
+        testee.markAsUnsynced()
+        expect(testee.getRank()).toBe(rank - 1)
+      })
 
-      const testee: Part = new Part({ pieces, segmentId: 'segmentId' } as PartInterface)
-      testee.markAsUnsynced()
+      describe('segment id already have the unsynced postfix', () => {
+        const ingestedPart: IngestedPart = {} as IngestedPart
+        it('does not add an extra postfix', () => {
+          const segmentIdWithPostfix: string = `someSegmentId${UNSYNCED_ID_POSTFIX}`
+          const testee: Part = new Part({ ingestedPart, segmentId: segmentIdWithPostfix } as PartInterface)
+          testee.markAsUnsynced()
+          expect(testee.getSegmentId()).toBe(segmentIdWithPostfix)
+        })
+      })
 
-      verify(pieceOne.markAsUnsyncedWithUnsyncedPart()).once()
-      verify(pieceTwo.markAsUnsyncedWithUnsyncedPart()).once()
-      verify(pieceThree.markAsUnsyncedWithUnsyncedPart()).once()
-    })
+      it('marks all its Pieces as unsynced', () => {
+        const pieceOne: Piece = EntityMockFactory.createPieceMock({ id: '1' } as PieceInterface)
+        const pieceTwo: Piece = EntityMockFactory.createPieceMock({ id: '2' } as PieceInterface)
+        const pieceThree: Piece = EntityMockFactory.createPieceMock({ id: '3' } as PieceInterface)
 
-    it('converts all its pieces into unsynced copies', () => {
-      const pieceOne: Piece = EntityTestFactory.createPiece({ id: '1' } as PieceInterface)
-      const pieceTwo: Piece = EntityTestFactory.createPiece({ id: '2' } as PieceInterface)
-      const pieceThree: Piece = EntityTestFactory.createPiece({ id: '3' } as PieceInterface)
+        const pieces: Piece[] = [
+          instance(pieceOne),
+          instance(pieceTwo),
+          instance(pieceThree)
+        ]
 
-      const pieces: Piece[] = [pieceOne, pieceTwo, pieceThree]
+        const ingestedPart: IngestedPart = {} as IngestedPart
+        const testee: Part = new Part({ pieces, ingestedPart, segmentId: 'segmentId' } as PartInterface)
+        testee.markAsUnsynced()
 
-      const testee: Part = new Part({ pieces, segmentId: 'segmentId' } as PartInterface)
+        verify(pieceOne.markAsUnsyncedWithUnsyncedPart()).once()
+        verify(pieceTwo.markAsUnsyncedWithUnsyncedPart()).once()
+        verify(pieceThree.markAsUnsyncedWithUnsyncedPart()).once()
+      })
 
-      testee.markAsUnsynced()
+      it('converts all its pieces into unsynced copies', () => {
+        const pieceOne: Piece = EntityTestFactory.createPiece({ id: '1' } as PieceInterface)
+        const pieceTwo: Piece = EntityTestFactory.createPiece({ id: '2' } as PieceInterface)
+        const pieceThree: Piece = EntityTestFactory.createPiece({ id: '3' } as PieceInterface)
 
-      expect(testee.getPieces()).not.toEqual(pieces)
-      testee.getPieces().forEach(piece => expect(piece.id).toContain(UNSYNCED_ID_POSTFIX))
+        const pieces: Piece[] = [pieceOne, pieceTwo, pieceThree]
+
+        const ingestedPart: IngestedPart = {} as IngestedPart
+        const testee: Part = new Part({ pieces, ingestedPart, segmentId: 'segmentId' } as PartInterface)
+
+        testee.markAsUnsynced()
+
+        expect(testee.getPieces()).not.toEqual(pieces)
+        testee.getPieces().forEach(piece => expect(piece.id).toContain(UNSYNCED_ID_POSTFIX))
+      })
     })
   })
 

--- a/src/model/entities/test/rundown.spec.ts
+++ b/src/model/entities/test/rundown.spec.ts
@@ -3769,7 +3769,7 @@ describe(Rundown.name, () => {
             const nextPart: Part = EntityTestFactory.createPart({ isNext: true })
             const nextSegment: Segment = EntityTestFactory.createSegment({ parts: [nextPart] })
 
-            const expectedRank: number =  onAirPart.getRank() + 0.1
+            const expectedRank: number =  onAirPart.getRank() + 1
 
             const testee: Rundown = new Rundown({
               mode: RundownMode.ACTIVE,

--- a/src/model/entities/test/rundown.spec.ts
+++ b/src/model/entities/test/rundown.spec.ts
@@ -3675,6 +3675,92 @@ describe(Rundown.name, () => {
       })
     })
   })
+
+  describe(Rundown.prototype.insertPartAsNext.name, () => {
+    describe('there is no onAir Part', () => {
+      it ('throws an exception', () => {
+        const partToBeInserted: Part = EntityTestFactory.createPart({ id: 'partToBeInserted' })
+
+        const testee: Rundown = new Rundown({
+          mode: RundownMode.ACTIVE,
+          alreadyActiveProperties: {
+            activeCursor: undefined
+          }
+        } as RundownInterface)
+
+        expect(() => testee.insertPartAsNext(partToBeInserted)).toThrow()
+      })
+    })
+
+    describe('there is an onAir Part', () => {
+      describe('next Part is in the same Segment as the onAir Part', () => {
+        it('sets the rank of the inserted Part to be between the onAir and next Parts', () => {
+          const partToBeInserted: Part = EntityTestFactory.createPart({ id: 'partToBeInserted', rank: -1, ingestedPart: undefined })
+          const onAirPart: Part = EntityTestFactory.createPart({ isOnAir: true, rank: 5 })
+          const nextPart: Part = EntityTestFactory.createPart({ isNext: true, rank: 10 })
+          const onAirSegment: Segment = EntityTestFactory.createSegment({ parts: [onAirPart, nextPart] })
+
+          // The new rank is half the 'distance' between the onAir and next Parts plus the rank of the onAir Part.
+          const expectedRank: number =  (nextPart.getRank() - onAirPart.getRank()) / 2 + onAirPart.getRank()
+
+          const testee: Rundown = new Rundown({
+            mode: RundownMode.ACTIVE,
+            alreadyActiveProperties: {
+              activeCursor: {
+                segment: onAirSegment,
+                part: onAirPart,
+                owner: Owner.SYSTEM
+              },
+              nextCursor: {
+                segment: onAirSegment,
+                part: nextPart,
+                owner: Owner.SYSTEM
+              }
+            },
+            segments: [onAirSegment]
+          } as RundownInterface)
+
+          testee.insertPartAsNext(partToBeInserted)
+
+          expect(partToBeInserted.getRank()).toBe(expectedRank)
+        })
+      })
+
+      describe('next Part is another Segment', () => {
+        it ('sets the rank to be after the onAir Part', () => {
+          const partToBeInserted: Part = EntityTestFactory.createPart({ id: 'partToBeInserted', rank: -1, ingestedPart: undefined })
+          const onAirPart: Part = EntityTestFactory.createPart({ isOnAir: true, rank: 4 })
+          const onAirSegment: Segment = EntityTestFactory.createSegment({ parts: [onAirPart] })
+          const nextPart: Part = EntityTestFactory.createPart({ isNext: true })
+          const nextSegment: Segment = EntityTestFactory.createSegment({ parts: [nextPart] })
+
+          // The new rank is onAir Parts rank times 1.5
+          const expectedRank: number =  onAirPart.getRank() * 1.5
+
+          const testee: Rundown = new Rundown({
+            mode: RundownMode.ACTIVE,
+            alreadyActiveProperties: {
+              activeCursor: {
+                segment: onAirSegment,
+                part: onAirPart,
+                owner: Owner.SYSTEM
+              },
+              nextCursor: {
+                segment: nextSegment,
+                part: nextPart,
+                owner: Owner.SYSTEM
+              }
+            },
+            segments: [onAirSegment]
+          } as RundownInterface)
+
+          testee.insertPartAsNext(partToBeInserted)
+
+          expect(partToBeInserted.getRank()).toBe(expectedRank)
+        })
+      })
+    })
+  })
 })
 
 function createTesteeWithActiveAndNextCursors(params?: {

--- a/src/model/entities/test/rundown.spec.ts
+++ b/src/model/entities/test/rundown.spec.ts
@@ -3694,69 +3694,141 @@ describe(Rundown.name, () => {
 
     describe('there is an onAir Part', () => {
       describe('next Part is in the same Segment as the onAir Part', () => {
-        it('sets the rank of the inserted Part to be between the onAir and next Parts', () => {
-          const partToBeInserted: Part = EntityTestFactory.createPart({ id: 'partToBeInserted', rank: -1, ingestedPart: undefined })
-          const onAirPart: Part = EntityTestFactory.createPart({ isOnAir: true, rank: 5 })
-          const nextPart: Part = EntityTestFactory.createPart({ isNext: true, rank: 10 })
-          const onAirSegment: Segment = EntityTestFactory.createSegment({ parts: [onAirPart, nextPart] })
+        describe('next Part is right after the onAir Part', () => {
+          it('sets the rank of the inserted Part to be between the onAir and next Parts', () => {
+            const partToBeInserted: Part = EntityTestFactory.createPart({ id: 'partToBeInserted', rank: -1, ingestedPart: undefined })
+            const onAirPart: Part = EntityTestFactory.createPart({ isOnAir: true, rank: 5 })
+            const nextPart: Part = EntityTestFactory.createPart({ isNext: true, rank: 10 })
+            const onAirSegment: Segment = EntityTestFactory.createSegment({ parts: [onAirPart, nextPart] })
 
-          // The new rank is half the 'distance' between the onAir and next Parts plus the rank of the onAir Part.
-          const expectedRank: number =  (nextPart.getRank() - onAirPart.getRank()) / 2 + onAirPart.getRank()
+            const expectedRank: number =  (nextPart.getRank() - onAirPart.getRank()) / 2 + onAirPart.getRank()
 
-          const testee: Rundown = new Rundown({
-            mode: RundownMode.ACTIVE,
-            alreadyActiveProperties: {
-              activeCursor: {
-                segment: onAirSegment,
-                part: onAirPart,
-                owner: Owner.SYSTEM
+            const testee: Rundown = new Rundown({
+              mode: RundownMode.ACTIVE,
+              alreadyActiveProperties: {
+                activeCursor: {
+                  segment: onAirSegment,
+                  part: onAirPart,
+                  owner: Owner.SYSTEM
+                },
+                nextCursor: {
+                  segment: onAirSegment,
+                  part: nextPart,
+                  owner: Owner.SYSTEM
+                }
               },
-              nextCursor: {
-                segment: onAirSegment,
-                part: nextPart,
-                owner: Owner.SYSTEM
-              }
-            },
-            segments: [onAirSegment]
-          } as RundownInterface)
+              segments: [onAirSegment]
+            } as RundownInterface)
 
-          testee.insertPartAsNext(partToBeInserted)
+            testee.insertPartAsNext(partToBeInserted)
 
-          expect(partToBeInserted.getRank()).toBe(expectedRank)
+            expect(partToBeInserted.getRank()).toBe(expectedRank)
+          })
+        })
+
+        describe('next Part is not right after the onAir Part', () => {
+          it('sets the rank to be between the onAir Part and the part after the onAir Part', () => {
+            const partToBeInserted: Part = EntityTestFactory.createPart({ id: 'partToBeInserted', rank: -1, ingestedPart: undefined })
+            const onAirPart: Part = EntityTestFactory.createPart({ isOnAir: true, rank: 5 })
+            const partBetweenOnAirAndNextPart: Part = EntityTestFactory.createPart({ id: 'partBetweenOnAirAndNextPart', rank: 7 })
+            const nextPart: Part = EntityTestFactory.createPart({ isNext: true, rank: 10 })
+            const onAirSegment: Segment = EntityTestFactory.createSegment({ parts: [onAirPart, partBetweenOnAirAndNextPart, nextPart] })
+
+            const expectedRank: number =  (partBetweenOnAirAndNextPart.getRank() - onAirPart.getRank()) / 2 + onAirPart.getRank()
+
+            const testee: Rundown = new Rundown({
+              mode: RundownMode.ACTIVE,
+              alreadyActiveProperties: {
+                activeCursor: {
+                  segment: onAirSegment,
+                  part: onAirPart,
+                  owner: Owner.SYSTEM
+                },
+                nextCursor: {
+                  segment: onAirSegment,
+                  part: nextPart,
+                  owner: Owner.SYSTEM
+                }
+              },
+              segments: [onAirSegment]
+            } as RundownInterface)
+
+            testee.insertPartAsNext(partToBeInserted)
+
+            expect(partToBeInserted.getRank()).toBe(expectedRank)
+          })
         })
       })
 
       describe('next Part is another Segment', () => {
-        it ('sets the rank to be after the onAir Part', () => {
-          const partToBeInserted: Part = EntityTestFactory.createPart({ id: 'partToBeInserted', rank: -1, ingestedPart: undefined })
-          const onAirPart: Part = EntityTestFactory.createPart({ isOnAir: true, rank: 4 })
-          const onAirSegment: Segment = EntityTestFactory.createSegment({ parts: [onAirPart] })
-          const nextPart: Part = EntityTestFactory.createPart({ isNext: true })
-          const nextSegment: Segment = EntityTestFactory.createSegment({ parts: [nextPart] })
+        describe('onAir Part is last Part in the Segment', () => {
+          it('sets the rank to be the rank of the onAir Part plus 0.1', () => {
+            const partToBeInserted: Part = EntityTestFactory.createPart({ id: 'partToBeInserted', rank: -1, ingestedPart: undefined })
+            const onAirPart: Part = EntityTestFactory.createPart({ isOnAir: true, rank: 4 })
+            const onAirSegment: Segment = EntityTestFactory.createSegment({ parts: [onAirPart] })
+            const nextPart: Part = EntityTestFactory.createPart({ isNext: true })
+            const nextSegment: Segment = EntityTestFactory.createSegment({ parts: [nextPart] })
 
-          // The new rank is onAir Parts rank times 1.5
-          const expectedRank: number =  onAirPart.getRank() * 1.5
+            const expectedRank: number =  onAirPart.getRank() + 0.1
 
-          const testee: Rundown = new Rundown({
-            mode: RundownMode.ACTIVE,
-            alreadyActiveProperties: {
-              activeCursor: {
-                segment: onAirSegment,
-                part: onAirPart,
-                owner: Owner.SYSTEM
+            const testee: Rundown = new Rundown({
+              mode: RundownMode.ACTIVE,
+              alreadyActiveProperties: {
+                activeCursor: {
+                  segment: onAirSegment,
+                  part: onAirPart,
+                  owner: Owner.SYSTEM
+                },
+                nextCursor: {
+                  segment: nextSegment,
+                  part: nextPart,
+                  owner: Owner.SYSTEM
+                }
               },
-              nextCursor: {
-                segment: nextSegment,
-                part: nextPart,
-                owner: Owner.SYSTEM
-              }
-            },
-            segments: [onAirSegment]
-          } as RundownInterface)
+              segments: [onAirSegment]
+            } as RundownInterface)
 
-          testee.insertPartAsNext(partToBeInserted)
+            testee.insertPartAsNext(partToBeInserted)
 
-          expect(partToBeInserted.getRank()).toBe(expectedRank)
+            expect(partToBeInserted.getRank()).toBe(expectedRank)
+          })
+        })
+
+        describe('there is a Part after the onAir Part in the Segment', () => {
+          it ('sets the rank to be between the onAir Part and the Part after the onAir Part', () => {
+            const partToBeInserted: Part = EntityTestFactory.createPart({ id: 'partToBeInserted', rank: -1, ingestedPart: undefined })
+
+            const onAirPart: Part = EntityTestFactory.createPart({ isOnAir: true, rank: 4 })
+            const partAfterOnAirPart: Part = EntityTestFactory.createPart({ id: 'partAfterOnAirPart', rank: 6 })
+            const onAirSegment: Segment = EntityTestFactory.createSegment({ parts: [onAirPart, partAfterOnAirPart] })
+
+            const nextPart: Part = EntityTestFactory.createPart({ isNext: true })
+            const nextSegment: Segment = EntityTestFactory.createSegment({ parts: [nextPart] })
+
+            // The new rank is the rank of the onAir Part plus the distance between the onAir Part and the next Part: 4 + ((6 - 4) / 2)
+            const expectedRank: number =  5
+
+            const testee: Rundown = new Rundown({
+              mode: RundownMode.ACTIVE,
+              alreadyActiveProperties: {
+                activeCursor: {
+                  segment: onAirSegment,
+                  part: onAirPart,
+                  owner: Owner.SYSTEM
+                },
+                nextCursor: {
+                  segment: nextSegment,
+                  part: nextPart,
+                  owner: Owner.SYSTEM
+                }
+              },
+              segments: [onAirSegment]
+            } as RundownInterface)
+
+            testee.insertPartAsNext(partToBeInserted)
+
+            expect(partToBeInserted.getRank()).toBe(expectedRank)
+          })
         })
       })
     })


### PR DESCRIPTION
No longer mark unplanned Parts as unsynced. For a Part to be unsynced it needs to be unsynced from something. Unplanned Parts aren't included from the Newsroom so they technically can't be unsynced.

Also in this PR:
- Parts inserted into a Rundown will now get its rank updated to reflect its position in the Segment it is being inserted into.