### PR TITLE
Rundown reset emits set next event.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,14 @@
     "semi": ["error", "never"],
     "no-void": ["error"],
     "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ],
     "@typescript-eslint/explicit-member-accessibility": [
       "error",
       {

--- a/src/blueprints/tv2/timeline-object-factories/tv2-empty-graphics-command-timeline-object-factory.ts
+++ b/src/blueprints/tv2/timeline-object-factories/tv2-empty-graphics-command-timeline-object-factory.ts
@@ -5,7 +5,6 @@ import { DeviceType } from '../../../model/enums/device-type'
 
 export class Tv2EmptyGraphicsCommandTimelineObjectFactory implements Tv2GraphicsCommandTimelineObjectFactory {
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public createAllOutGraphicsTimelineObject(_blueprintConfiguration: Tv2BlueprintConfiguration): EmptyTimelineObject {
     return this.createNeverTimelineObject()
   }
@@ -22,7 +21,6 @@ export class Tv2EmptyGraphicsCommandTimelineObjectFactory implements Tv2Graphics
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public createClearGraphicsTimelineObject(_blueprintConfiguration: Tv2BlueprintConfiguration): EmptyTimelineObject {
     return this.createNeverTimelineObject()
   }
@@ -35,7 +33,6 @@ export class Tv2EmptyGraphicsCommandTimelineObjectFactory implements Tv2Graphics
     return this.createNeverTimelineObject()
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public createThemeOutTimelineObject(_blueprintConfiguration: Tv2BlueprintConfiguration): EmptyTimelineObject {
     return this.createNeverTimelineObject()
   }

--- a/src/blueprints/tv2/timeline-object-factories/tv2-tri-caster-video-mixer-timeline-object-factory.ts
+++ b/src/blueprints/tv2/timeline-object-factories/tv2-tri-caster-video-mixer-timeline-object-factory.ts
@@ -288,7 +288,6 @@ export class Tv2TriCasterVideoMixerTimelineObjectFactory implements Tv2VideoMixe
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public createSplitScreenPropertiesTimelineObject(configuration: Tv2BlueprintConfiguration, _layoutProperties: SplitScreenLayoutProperties): TriCasterMixEffectTimelineObject {
     return {
       id: `${TRI_CASTER_PREFIX}split_screen_properties`,
@@ -348,7 +347,6 @@ export class Tv2TriCasterVideoMixerTimelineObjectFactory implements Tv2VideoMixe
     ]
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public createDipTransitionEffectTimelineObjects(sourceInput: number, durationInFrames: number, _dipInput: number): TriCasterMixEffectTimelineObject[] {
     return [
       this.createTransitionEffectTimelineObject(Tv2TriCasterLayer.PROGRAM, sourceInput, TriCasterTransition.DIP, durationInFrames),

--- a/src/business-logic/services/rundown-timeline-service.ts
+++ b/src/business-logic/services/rundown-timeline-service.ts
@@ -222,6 +222,7 @@ export class RundownTimelineService implements RundownService {
     await this.buildAndPersistTimeline(rundown)
 
     this.rundownEventEmitter.emitResetEvent(rundown)
+    this.rundownEventEmitter.emitSetNextEvent(rundown)
 
     await this.saveRundown(rundown)
   }

--- a/src/business-logic/services/test/rundown-timeline-service.spec.ts
+++ b/src/business-logic/services/test/rundown-timeline-service.spec.ts
@@ -357,6 +357,73 @@ describe(RundownTimelineService.name, () => {
       })
     })
   })
+
+  describe(RundownTimelineService.prototype.resetRundown.name, () => {
+    describe('when rundown is in rehearsal', () => {
+      it('is still in rehearsal after reset', async () => {
+        const rundown: Rundown = EntityTestFactory.createRundown({
+          id: 'rundown-id',
+          segments: [EntityTestFactory.createSegment({
+            parts: [EntityTestFactory.createPart()]
+          })],
+        })
+
+        const rundownRepository: RundownRepository = mock<RundownRepository>()
+        when(rundownRepository.getRundown(rundown.id)).thenResolve(rundown)
+
+        const testee: RundownTimelineService = createTestee({ rundownRepository: instance(rundownRepository) })
+        rundown.enterRehearsal()
+        expect(rundown.isRehearsal()).toBeTruthy()
+
+        await testee.resetRundown(rundown.id)
+
+        expect(rundown.isRehearsal()).toBeTruthy()
+      })
+    })
+
+    describe('when rundown is active', () => {
+      it('is still active after reset', async () => {
+        const rundown: Rundown = EntityTestFactory.createRundown({
+          id: 'rundown-id',
+          segments: [EntityTestFactory.createSegment({
+            parts: [EntityTestFactory.createPart()]
+          })],
+        })
+
+        const rundownRepository: RundownRepository = mock<RundownRepository>()
+        when(rundownRepository.getRundown(rundown.id)).thenResolve(rundown)
+
+        const testee: RundownTimelineService = createTestee({ rundownRepository: instance(rundownRepository) })
+        rundown.activate()
+        expect(rundown.isActive()).toBeTruthy()
+
+        await testee.resetRundown(rundown.id)
+
+        expect(rundown.isActive()).toBeTruthy()
+      })
+    })
+
+    it('emits set next event after reset event', async () => {
+      const rundown: Rundown = EntityTestFactory.createRundown({
+        id: 'rundown-id',
+        segments: [EntityTestFactory.createSegment({
+          parts: [EntityTestFactory.createPart()]
+        })],
+      })
+
+      const rundownRepository: RundownRepository = mock<RundownRepository>()
+      when(rundownRepository.getRundown(rundown.id)).thenResolve(rundown)
+
+      const rundownEventEmitter: RundownEventEmitter = mock<RundownEventEmitter>()
+
+      const testee: RundownTimelineService = createTestee({ rundownRepository: instance(rundownRepository), rundownEventEmitter: instance(rundownEventEmitter) })
+      rundown.activate()
+
+      await testee.resetRundown(rundown.id)
+
+      verify(rundownEventEmitter.emitSetNextEvent(rundown)).calledAfter(rundownEventEmitter.emitResetEvent(rundown))
+    })
+  })
 })
 
 function createTestee(params?: {

--- a/src/data-access/repositories/mongo/mongo-device-changed-listener.ts
+++ b/src/data-access/repositories/mongo/mongo-device-changed-listener.ts
@@ -59,7 +59,6 @@ export class MongoDeviceChangedListener extends BaseMongoRepository implements D
     this.onUpdatedCallback = onUpdatedCallback
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public onDeleted(_onDeletedCallback: (id: string) => void): void {
     throw new UnsupportedOperationException(`${MongoDeviceChangedListener.name} does not support ${MongoDeviceChangedListener.prototype.onDeleted.name}`)
   }

--- a/src/data-access/repositories/mongo/mongo-show-style-configuration-changed-listener.ts
+++ b/src/data-access/repositories/mongo/mongo-show-style-configuration-changed-listener.ts
@@ -37,7 +37,6 @@ export class MongoShowStyleConfigurationChangedListener extends BaseMongoReposit
     this.onUpdatedCallback({} as ShowStyle)
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public onCreated(_onCreatedCallback: (showStyle: ShowStyle) => void): void {
     throw new UnsupportedOperationException(
       `${MongoShowStyleConfigurationChangedListener.prototype.onCreated.name} is not supported in ${MongoShowStyleConfigurationChangedListener.name}`
@@ -48,7 +47,6 @@ export class MongoShowStyleConfigurationChangedListener extends BaseMongoReposit
     this.onUpdatedCallback = onUpdatedCallback
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public onDeleted(_onDeletedCallback: (id: string) => void): void {
     throw new UnsupportedOperationException(
       `${MongoShowStyleConfigurationChangedListener.prototype.onDeleted.name} is not supported in ${MongoShowStyleConfigurationChangedListener.name}`


### PR DESCRIPTION
To indicate that a part is set as next when resetting the rundown, a set next event is now emitted on rundown reset.
The PR adds a few tests for the `RundownTimelineService.resetRundown` method and changes the linting setup to allow unused variables if they start with an underscore.