### PR TITLE
SOF-2006/ Duplicating Segments Transfers referenceTag

### DIFF
--- a/src/business-logic/services/ingested-entity-to-entity-mapper.ts
+++ b/src/business-logic/services/ingested-entity-to-entity-mapper.ts
@@ -54,6 +54,7 @@ export class IngestedEntityToEntityMapper {
       name: ingestedSegment.name,
       rank: ingestedSegment.rank,
       isHidden: ingestedSegment.isHidden,
+      referenceTag: ingestedSegment.referenceTag,
       metadata: ingestedSegment.metadata,
       isOnAir: false,
       isNext: false,


### PR DESCRIPTION
This fix ensures that we also map over the referenceTag when we convert from `ingestedSegment` to `segment`.