### PR TITLE
SOF-2007 SplitScreens blink when Taken with VideoClip

### DIFF
--- a/src/blueprints/tv2/action-factories/tv2-split-screen-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-split-screen-action-factory.ts
@@ -213,7 +213,7 @@ export class Tv2SplitScreenActionFactory extends ActionFactory {
 
   private createSplitScreenPieceInterface(partId: string, name: string, metadata: Tv2PieceMetadata, timelineObjects: Tv2BlueprintTimelineObject[]): Tv2PieceInterface {
     return {
-      id: `${partId}_piece`,
+      id: `${partId}_piece_${Date.now()}`,
       partId,
       name,
       layer: Tv2SourceLayer.SPLIT_SCREEN,
@@ -233,7 +233,7 @@ export class Tv2SplitScreenActionFactory extends ActionFactory {
 
   private createSplitScreenPieceInterfaceFromPiece(piece: Piece, metadata: Tv2PieceMetadata, timelineObjects: Tv2BlueprintTimelineObject[]): Tv2PieceInterface {
     return {
-      id: `${piece.getPartId()}_piece`,
+      id: `${piece.getPartId()}_piece_${Date.now()}`,
       partId: piece.getPartId(),
       name: piece.name,
       layer: Tv2SourceLayer.SPLIT_SCREEN,

--- a/src/blueprints/tv2/action-factories/tv2-split-screen-action-factory.ts
+++ b/src/blueprints/tv2/action-factories/tv2-split-screen-action-factory.ts
@@ -231,6 +231,26 @@ export class Tv2SplitScreenActionFactory extends ActionFactory {
     }
   }
 
+  private createSplitScreenPieceInterfaceFromPiece(piece: Piece, metadata: Tv2PieceMetadata, timelineObjects: Tv2BlueprintTimelineObject[]): Tv2PieceInterface {
+    return {
+      id: `${piece.getPartId()}_piece`,
+      partId: piece.getPartId(),
+      name: piece.name,
+      layer: Tv2SourceLayer.SPLIT_SCREEN,
+      pieceLifespan: PieceLifespan.WITHIN_PART,
+      transitionType: TransitionType.NO_TRANSITION,
+      isPlanned: false,
+      isUnsynced: false,
+      start: piece.getStart(),
+      duration: piece.getDuration(),
+      preRollDuration: piece.preRollDuration,
+      postRollDuration: piece.postRollDuration,
+      tags: [],
+      metadata,
+      timelineObjects
+    }
+  }
+
   private createInsertSplitScreenInputActions(blueprintConfiguration: Tv2BlueprintConfiguration): Tv2SplitScreenInsertSourceInputAction[] {
     const cameraSources: Tv2SourceMappingWithSound[] = blueprintConfiguration.studio.cameraSources.slice(0, 5)
     const remoteSources: Tv2SourceMappingWithSound[] = blueprintConfiguration.studio.remoteSources
@@ -332,7 +352,7 @@ export class Tv2SplitScreenActionFactory extends ActionFactory {
 
     const splitScreenAction: Tv2SplitScreenInsertSourceInputAction = action as Tv2SplitScreenInsertSourceInputAction
     splitScreenAction.data = {
-      pieceInterface: this.createSplitScreenPieceInterface(splitScreenPieceFromRundown.getPartId(), splitScreenPieceFromRundown.name, pieceMetadata, timelineObjects)
+      pieceInterface: this.createSplitScreenPieceInterfaceFromPiece(splitScreenPieceFromRundown, pieceMetadata, timelineObjects)
     }
     return splitScreenAction
   }
@@ -640,7 +660,7 @@ export class Tv2SplitScreenActionFactory extends ActionFactory {
     }
 
     const isSplitScreenPart: boolean = this.doesPartHavePieceWithType(part, Tv2PieceType.SPLIT_SCREEN)
-    if (isSplitScreenPart) { // If the Part is a split screen we can't use it find the Video Clip we want to insert into the split screen.
+    if (isSplitScreenPart) { // If the Part is a split screen we can't use it to find the Video Clip we want to insert into the split screen.
       return false
     }
 


### PR DESCRIPTION
No longer set various duration of Piece to zero when inserting a VideoClip into a SplitScreen.

Inserting a VideoClip into a SplitScreen would set the various durations to zero. In the case of SplitScreen, we needed a `preRollDuration`, but since we overrode it to zero, we had a quarter of a second where we would show the "default" source which would give the illusion of a "blink":