### PR TITLE
Sof 2012/graphics actions get wrong graphics applied

### DIFF
--- a/src/blueprints/tv2/helpers/tv2-configuration-mapper.ts
+++ b/src/blueprints/tv2/helpers/tv2-configuration-mapper.ts
@@ -10,10 +10,10 @@ export class Tv2ConfigurationMapper {
     private readonly showStyleMapper: Tv2ShowStyleBlueprintConfigurationMapper
   ) {}
 
-  public mapBlueprintConfiguration(configuration: Configuration): Tv2BlueprintConfiguration {
+  public mapBlueprintConfiguration(configuration: Configuration, showStyleVariantId: string): Tv2BlueprintConfiguration {
     return {
       studio: this.studioMapper.mapStudioConfiguration(configuration.studio),
-      showStyle: this.showStyleMapper.mapShowStyleConfiguration(configuration.showStyle)
+      showStyle: this.showStyleMapper.mapShowStyleConfiguration(configuration.showStyle, showStyleVariantId)
     }
   }
 }

--- a/src/blueprints/tv2/helpers/tv2-show-style-blueprint-configuration-mapper.ts
+++ b/src/blueprints/tv2/helpers/tv2-show-style-blueprint-configuration-mapper.ts
@@ -72,8 +72,8 @@ interface CoreBreaker {
   LoadFirstFrame: boolean
 }
 
-interface CoreShowStyleVariantBlueprintConfiguration {
-  GfxDefaults: CoreGraphicsDefault[]
+export interface CoreShowStyleVariantBlueprintConfiguration {
+  GfxDefaults?: CoreGraphicsDefault[]
 }
 
 export class Tv2ShowStyleBlueprintConfigurationMapper {

--- a/src/blueprints/tv2/test/tv2-on-timeline-generate-service.spec.ts
+++ b/src/blueprints/tv2/test/tv2-on-timeline-generate-service.spec.ts
@@ -16,6 +16,7 @@ import { Tv2ConfigurationMapper } from '../helpers/tv2-configuration-mapper'
 
 const ACTIVE_GROUP_PREFIX: string = 'active_group_'
 const LOOKAHEAD_GROUP_ID: string = 'lookahead_group'
+const SHOW_STYLE_VARIANT_ID: string = 'showStyleVariantId'
 
 describe(Tv2OnTimelineGenerateService.name, () => {
   describe(`${Tv2OnTimelineGenerateService.prototype.onTimelineGenerate.name}`, () => {
@@ -29,7 +30,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
         const previousPart: Part = EntityMockFactory.createPart({ segmentId })
 
         const testee: Tv2OnTimelineGenerateService = createTestee()
-        const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, activePart, rundownPersistentState, previousPart)
+        const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, activePart, rundownPersistentState, previousPart)
         const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
         expect(result.isNewSegment).toBeFalsy()
@@ -45,7 +46,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
         const previousPart: Part = EntityMockFactory.createPart({ segmentId: 'someOtherSegmentId' })
 
         const testee: Tv2OnTimelineGenerateService = createTestee()
-        const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, activePart, rundownPersistentState, previousPart)
+        const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, activePart, rundownPersistentState, previousPart)
         const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
         expect(result.isNewSegment).toBeTruthy()
@@ -63,7 +64,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
           const part: Part = EntityMockFactory.createPart()
 
           const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
           const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
           expect(result.activeMediaPlayerSessions).toHaveLength(0)
@@ -85,7 +86,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
           const part: Part = EntityMockFactory.createPart()
 
           const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
           const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
           expect(result.activeMediaPlayerSessions).toHaveLength(1)
@@ -108,7 +109,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
           const part: Part = EntityMockFactory.createPart()
 
           const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
           const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
           expect(result.activeMediaPlayerSessions).toHaveLength(1)
@@ -133,7 +134,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
           const part: Part = EntityMockFactory.createPart()
 
           const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
           const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
           expect(result.activeMediaPlayerSessions).toHaveLength(2)
@@ -159,7 +160,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
           const part: Part = EntityMockFactory.createPart()
 
           const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
           const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
           expect(result.activeMediaPlayerSessions).toHaveLength(2)
@@ -188,7 +189,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
             const part: Part = EntityMockFactory.createPart()
 
             const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-            const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+            const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
             const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
             expect(result.activeMediaPlayerSessions).toHaveLength(2)
@@ -214,7 +215,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
           const part: Part = EntityMockFactory.createPart()
 
           const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
           const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
           expect(result.activeMediaPlayerSessions).toHaveLength(1)
@@ -241,7 +242,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
           const part: Part = EntityMockFactory.createPart()
 
           const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
           const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
           expect(result.activeMediaPlayerSessions).toHaveLength(0)
@@ -270,7 +271,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
           const part: Part = EntityMockFactory.createPart()
 
           const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
           const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
           expect(result.activeMediaPlayerSessions).toHaveLength(1)
@@ -304,7 +305,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
             const part: Part = EntityMockFactory.createPart()
 
             const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-            const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+            const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
             const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
             expect(result.activeMediaPlayerSessions).toHaveLength(2)
@@ -344,7 +345,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
             const part: Part = EntityMockFactory.createPart()
 
             const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-            const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+            const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
             const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
             expect(result.activeMediaPlayerSessions).toHaveLength(2)
@@ -385,7 +386,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
             const part: Part = EntityMockFactory.createPart()
 
             const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-            const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+            const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
             const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
             expect(result.activeMediaPlayerSessions).toHaveLength(2)
@@ -430,7 +431,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
           const part: Part = EntityMockFactory.createPart()
 
           const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
           const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
           expect(result.activeMediaPlayerSessions).toHaveLength(2)
@@ -475,7 +476,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
             const part: Part = EntityMockFactory.createPart()
 
             const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-            const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+            const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
             const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
             expect(result.activeMediaPlayerSessions).toHaveLength(2)
@@ -517,7 +518,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
           const part: Part = EntityMockFactory.createPart()
 
           const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+          const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
           const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
           expect(result.activeMediaPlayerSessions).toHaveLength(1)
@@ -558,7 +559,7 @@ describe(Tv2OnTimelineGenerateService.name, () => {
             const part: Part = EntityMockFactory.createPart()
 
             const testee: Tv2OnTimelineGenerateService = createTestee({ mediaPlayerIds })
-            const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, timeline, part,  rundownPersistentState, undefined)
+            const onTimelineGenerateResult: OnTimelineGenerateResult = testee.onTimelineGenerate(configuration, SHOW_STYLE_VARIANT_ID, timeline, part,  rundownPersistentState, undefined)
             const result: Tv2RundownPersistentState = onTimelineGenerateResult.rundownPersistentState as Tv2RundownPersistentState
 
             expect(result.activeMediaPlayerSessions).toHaveLength(2)
@@ -586,7 +587,7 @@ function createTestee(params?: {
   }
   const mediaPlayerIds: string[] = params && params.mediaPlayerIds ? params.mediaPlayerIds : []
   const configurationMapperMock: Tv2ConfigurationMapper = mock(Tv2ConfigurationMapper)
-  when(configurationMapperMock.mapBlueprintConfiguration(anything())).thenReturn(createConfiguration(mediaPlayerIds))
+  when(configurationMapperMock.mapBlueprintConfiguration(anything(), SHOW_STYLE_VARIANT_ID)).thenReturn(createConfiguration(mediaPlayerIds))
   return new Tv2OnTimelineGenerateService(instance(configurationMapperMock), sisyfosPersistentLayerFinder!)
 }
 

--- a/src/blueprints/tv2/tv2-action-service.ts
+++ b/src/blueprints/tv2/tv2-action-service.ts
@@ -73,8 +73,8 @@ export class Tv2ActionService implements BlueprintGenerateActions {
     return []
   }
 
-  public generateActions(configuration: Configuration, actionManifests: Tv2ActionManifest[]): Action[] {
-    const blueprintConfiguration: Tv2BlueprintConfiguration = this.configurationMapper.mapBlueprintConfiguration(configuration)
+  public generateActions(configuration: Configuration, showStyleVariantId: string, actionManifests: Tv2ActionManifest[]): Action[] {
+    const blueprintConfiguration: Tv2BlueprintConfiguration = this.configurationMapper.mapBlueprintConfiguration(configuration, showStyleVariantId)
     this.setFactories(blueprintConfiguration)
 
     return [

--- a/src/blueprints/tv2/tv2-blueprint-configuration-validator.ts
+++ b/src/blueprints/tv2/tv2-blueprint-configuration-validator.ts
@@ -12,7 +12,7 @@ export class Tv2BlueprintConfigurationValidator implements BlueprintValidateConf
 
 
   public validateConfiguration(configuration: Configuration): StatusMessage[] {
-    const tv2BlueprintConfiguration: Tv2BlueprintConfiguration = this.configurationMapper.mapBlueprintConfiguration(configuration)
+    const tv2BlueprintConfiguration: Tv2BlueprintConfiguration = this.configurationMapper.mapBlueprintConfiguration(configuration, '')
     // Add validation as needed.
     return [
       ...this.validateShowStyleConfiguration(tv2BlueprintConfiguration.showStyle)

--- a/src/blueprints/tv2/tv2-blueprint-configuration-validator.ts
+++ b/src/blueprints/tv2/tv2-blueprint-configuration-validator.ts
@@ -45,7 +45,7 @@ export class Tv2BlueprintConfigurationValidator implements BlueprintValidateConf
 
   private validateShowStyleVariants(showStyleVariants: ShowStyleVariant[]): StatusMessage[] {
     return showStyleVariants
-      .filter(variant => !(variant.blueprintConfiguration as CoreShowStyleVariantBlueprintConfiguration).GfxDefaults)
+      .filter(variant => !Array.isArray((variant.blueprintConfiguration as CoreShowStyleVariantBlueprintConfiguration).GfxDefaults))
       .map(variant => {
         return {
           id: `${variant.id}_noGraphicsDefault`,

--- a/src/blueprints/tv2/tv2-blueprint-configuration-validator.ts
+++ b/src/blueprints/tv2/tv2-blueprint-configuration-validator.ts
@@ -5,6 +5,8 @@ import { Tv2ConfigurationMapper } from './helpers/tv2-configuration-mapper'
 import { Tv2BlueprintConfiguration } from './value-objects/tv2-blueprint-configuration'
 import { Tv2ShowStyleBlueprintConfiguration } from './value-objects/tv2-show-style-blueprint-configuration'
 import { StatusCode } from '../../model/enums/status-code'
+import { ShowStyleVariant } from '../../model/entities/show-style-variant'
+import { CoreShowStyleVariantBlueprintConfiguration } from './helpers/tv2-show-style-blueprint-configuration-mapper'
 
 export class Tv2BlueprintConfigurationValidator implements BlueprintValidateConfiguration {
 
@@ -15,7 +17,8 @@ export class Tv2BlueprintConfigurationValidator implements BlueprintValidateConf
     const tv2BlueprintConfiguration: Tv2BlueprintConfiguration = this.configurationMapper.mapBlueprintConfiguration(configuration, '')
     // Add validation as needed.
     return [
-      ...this.validateShowStyleConfiguration(tv2BlueprintConfiguration.showStyle)
+      ...this.validateShowStyleConfiguration(tv2BlueprintConfiguration.showStyle),
+      ...this.validateShowStyleVariants(configuration.showStyle.variants)
     ]
   }
 
@@ -38,5 +41,18 @@ export class Tv2BlueprintConfigurationValidator implements BlueprintValidateConf
           }
         })
     })
+  }
+
+  private validateShowStyleVariants(showStyleVariants: ShowStyleVariant[]): StatusMessage[] {
+    return showStyleVariants
+      .filter(variant => !(variant.blueprintConfiguration as CoreShowStyleVariantBlueprintConfiguration).GfxDefaults)
+      .map(variant => {
+        return {
+          id: `${variant.id}_noGraphicsDefault`,
+          title: `Misconfigured ShowStyleVariant ${variant.name}`,
+          message: `ShowStyleVariant ${variant.name} does not have a 'GraphicsDefault' configured.`,
+          statusCode: StatusCode.BAD
+        }
+      })
   }
 }

--- a/src/blueprints/tv2/tv2-blueprint.ts
+++ b/src/blueprints/tv2/tv2-blueprint.ts
@@ -32,6 +32,7 @@ export class Tv2Blueprint implements Blueprint {
 
   public onTimelineGenerate(
     configuration: Configuration,
+    showStyleVariantId: string,
     timeline: Timeline,
     activePart: Part,
     previousRundownPersistentState: RundownPersistentState | undefined,
@@ -42,6 +43,7 @@ export class Tv2Blueprint implements Blueprint {
     } {
     return this.onTimelineGenerateService.onTimelineGenerate(
       configuration,
+      showStyleVariantId,
       timeline,
       activePart,
       previousRundownPersistentState,
@@ -49,8 +51,8 @@ export class Tv2Blueprint implements Blueprint {
     )
   }
 
-  public generateActions(configuration: Configuration, actionManifests: ActionManifest[]): Action[] {
-    return this.actionsService.generateActions(configuration, actionManifests)
+  public generateActions(configuration: Configuration, showStyleVariantId: string, actionManifests: ActionManifest[]): Action[] {
+    return this.actionsService.generateActions(configuration, showStyleVariantId, actionManifests)
   }
 
   public getMutateActionMethods(action: Tv2Action): MutateActionMethods[] {

--- a/src/blueprints/tv2/tv2-on-timeline-generate-service.ts
+++ b/src/blueprints/tv2/tv2-on-timeline-generate-service.ts
@@ -37,12 +37,13 @@ export class Tv2OnTimelineGenerateService implements BlueprintOnTimelineGenerate
 
   public onTimelineGenerate(
     configuration: Configuration,
+    showStyleVariantId: string,
     timeline: Timeline,
     activePart: Part,
     previousRundownPersistentState: RundownPersistentState | undefined,
     previousPart: Part | undefined,
   ): OnTimelineGenerateResult {
-    const blueprintConfiguration: Tv2BlueprintConfiguration = this.configurationMapper.mapBlueprintConfiguration(configuration)
+    const blueprintConfiguration: Tv2BlueprintConfiguration = this.configurationMapper.mapBlueprintConfiguration(configuration, showStyleVariantId)
 
     const rundownPersistentState: Tv2RundownPersistentState = (previousRundownPersistentState ?? this.getEmptyTv2RundownPersistentState()) as Tv2RundownPersistentState
     const newRundownPersistentState: Tv2RundownPersistentState = {

--- a/src/blueprints/tv2/value-objects/tv2-show-style-blueprint-configuration.ts
+++ b/src/blueprints/tv2/value-objects/tv2-show-style-blueprint-configuration.ts
@@ -118,3 +118,7 @@ export interface Breaker {
   autoNext: boolean,
   shouldLoadFirstFrame: boolean
 }
+
+export interface Tv2ShowStyleVariantBlueprintConfiguration {
+  graphicsDefault: GraphicsDefault
+}

--- a/src/business-logic/facades/service-facade.ts
+++ b/src/business-logic/facades/service-facade.ts
@@ -133,6 +133,7 @@ export class ServiceFacade {
       ServiceFacade.createStatusMessageService(),
       RepositoryFacade.createConfigurationRepository(),
       RepositoryFacade.createShowStyleChangedListener(),
+      RepositoryFacade.createShowStyleVariantConfigurationListener(),
       LoggerFacade.createLogger()
     )
   }

--- a/src/business-logic/services/blueprint-timeline-builder.ts
+++ b/src/business-logic/services/blueprint-timeline-builder.ts
@@ -41,6 +41,7 @@ export class BlueprintTimelineBuilder implements TimelineBuilder {
 
     return this.blueprint.onTimelineGenerate(
       configuration,
+      rundown.getShowStyleVariantId(),
       timeline,
       rundown.getActivePart(),
       rundown.getPersistentState(),

--- a/src/business-logic/services/configuration-changed-service.ts
+++ b/src/business-logic/services/configuration-changed-service.ts
@@ -8,6 +8,7 @@ import { Configuration } from '../../model/entities/configuration'
 import { StatusMessageService } from './interfaces/status-message-service'
 import { Logger } from '../../logger/logger'
 import { UnsupportedOperationException } from '../../model/exceptions/unsupported-operation-exception'
+import { ShowStyleVariant } from '../../model/entities/show-style-variant'
 
 const CONFIGURATION_STATUS_MESSAGE_ID_PREFIX: string = 'INVALID_CONFIGURATION_'
 
@@ -20,6 +21,7 @@ export class ConfigurationChangedService implements DataChangeService {
     statusMessageService: StatusMessageService,
     configurationRepository: ConfigurationRepository,
     showStyleConfigurationChangedListener: DataChangedListener<ShowStyle>,
+    showStyleVariantConfigurationChangedListener: DataChangedListener<ShowStyleVariant>,
     logger: Logger
   ): DataChangeService {
     if (!this.instance) {
@@ -28,6 +30,7 @@ export class ConfigurationChangedService implements DataChangeService {
         statusMessageService,
         configurationRepository,
         showStyleConfigurationChangedListener,
+        showStyleVariantConfigurationChangedListener,
         logger
       )
     }
@@ -41,19 +44,21 @@ export class ConfigurationChangedService implements DataChangeService {
     private readonly statusMessageService: StatusMessageService,
     private readonly configurationRepository: ConfigurationRepository,
     showStyleConfigurationChangedListener: DataChangedListener<ShowStyle>,
+    showStyleVariantConfigurationChangedListener: DataChangedListener<ShowStyleVariant>,
     logger: Logger
   ) {
     this.logger = logger.tag(ConfigurationChangedService.name)
     this.validateConfiguration().catch(error => this.logger.data(error).error('Failed to validate configuration'))
-    this.listenForShowStyleChanges(showStyleConfigurationChangedListener)
+    this.validateConfigurationOnChange(showStyleConfigurationChangedListener)
+    this.validateConfigurationOnChange(showStyleVariantConfigurationChangedListener)
   }
 
   public initialize(): Promise<void> {
     throw new UnsupportedOperationException('Not implemented')
   }
 
-  private listenForShowStyleChanges(showStyleConfigurationChangedListener: DataChangedListener<ShowStyle>): void {
-    showStyleConfigurationChangedListener.onUpdated(() => {
+  private validateConfigurationOnChange<T>(dataChangedListener: DataChangedListener<T>): void {
+    dataChangedListener.onUpdated(() => {
       this.validateConfiguration().catch(error => this.logger.data(error).error('Failed to validate configuration'))
     })
   }

--- a/src/data-access/facades/repository-facade.ts
+++ b/src/data-access/facades/repository-facade.ts
@@ -70,6 +70,10 @@ import {
   MongoShowStyleConfigurationChangedListener
 } from '../repositories/mongo/mongo-show-style-configuration-changed-listener'
 import { Database } from '../repositories/interfaces/database'
+import { ShowStyleVariant } from '../../model/entities/show-style-variant'
+import {
+  MongoShowStyleVariantConfigurationListener
+} from '../repositories/mongo/mongo-show-style-variant-configuration-listener'
 
 export class RepositoryFacade {
 
@@ -200,6 +204,10 @@ export class RepositoryFacade {
 
   public static createShowStyleChangedListener(): DataChangedListener<ShowStyle> {
     return new MongoShowStyleConfigurationChangedListener(MongoDatabase.getInstance(LoggerFacade.createLogger()), LoggerFacade.createLogger())
+  }
+
+  public static createShowStyleVariantConfigurationListener(): DataChangedListener<ShowStyleVariant> {
+    return new MongoShowStyleVariantConfigurationListener(MongoDatabase.getInstance(LoggerFacade.createLogger()), LoggerFacade.createLogger())
   }
 
   public static createShelfConfigurationRepository(): ShelfConfigurationRepository {

--- a/src/data-access/facades/repository-facade.ts
+++ b/src/data-access/facades/repository-facade.ts
@@ -191,7 +191,11 @@ export class RepositoryFacade {
   }
 
   private static createShowStyleRepository(): ShowStyleRepository {
-    return new MongoShowStyleRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter())
+    return new MongoShowStyleRepository(
+      MongoDatabase.getInstance(LoggerFacade.createLogger()),
+      RepositoryFacade.createShowStyleVariantRepository(),
+      new MongoEntityConverter()
+    )
   }
 
   public static createShowStyleChangedListener(): DataChangedListener<ShowStyle> {

--- a/src/data-access/repositories/interfaces/show-style-variant-repository.ts
+++ b/src/data-access/repositories/interfaces/show-style-variant-repository.ts
@@ -1,5 +1,6 @@
 import { ShowStyleVariant } from '../../../model/entities/show-style-variant'
 
 export interface ShowStyleVariantRepository {
+  getShowStyleVariantsForShowStyle(showStyleId: string): Promise<ShowStyleVariant[]>
   getShowStyleVariant(rundownId: string): Promise<ShowStyleVariant>
 }

--- a/src/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/src/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -447,7 +447,7 @@ export class MongoEntityConverter {
     }
   }
 
-  public convertShowStyle(mongoShowStyle: MongoShowStyle, showStyleVariants: ShowStyleVariant[] = []): ShowStyle {
+  public convertShowStyle(mongoShowStyle: MongoShowStyle, showStyleVariants: ShowStyleVariant[]): ShowStyle {
     return {
       blueprintConfiguration: mongoShowStyle.blueprintConfig,
       variants: showStyleVariants

--- a/src/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/src/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -447,10 +447,15 @@ export class MongoEntityConverter {
     }
   }
 
-  public convertShowStyle(mongoShowStyle: MongoShowStyle): ShowStyle {
+  public convertShowStyle(mongoShowStyle: MongoShowStyle, showStyleVariants: ShowStyleVariant[] = []): ShowStyle {
     return {
       blueprintConfiguration: mongoShowStyle.blueprintConfig,
+      variants: showStyleVariants
     }
+  }
+
+  public convertShowStyleVariants(mongoShowStyleVariants: MongoShowStyleVariant[]): ShowStyleVariant[] {
+    return mongoShowStyleVariants.map(this.convertShowStyleVariant)
   }
 
   public convertShowStyleVariant(mongoShowStyleVariant: MongoShowStyleVariant): ShowStyleVariant {

--- a/src/data-access/repositories/mongo/mongo-show-style-configuration-changed-listener.ts
+++ b/src/data-access/repositories/mongo/mongo-show-style-configuration-changed-listener.ts
@@ -3,7 +3,6 @@ import { ShowStyle } from '../../../model/entities/show-style'
 import { MongoDatabase } from './mongo-database'
 import { BaseMongoRepository } from './base-mongo-repository'
 import { ChangeStream, ChangeStreamDocument, ChangeStreamOptions } from 'mongodb'
-import { MongoIngestedRundown } from './mongo-ingested-entity-converter'
 import { Logger } from '../../../logger/logger'
 import { UnsupportedOperationException } from '../../../model/exceptions/unsupported-operation-exception'
 
@@ -27,7 +26,7 @@ export class MongoShowStyleConfigurationChangedListener extends BaseMongoReposit
 
   protected listenForChanges(): void {
     const options: ChangeStreamOptions = { fullDocument: 'updateLookup' }
-    const changeStream: ChangeStream = this.getCollection().watch<MongoIngestedRundown, ChangeStreamDocument<ShowStyle>>([], options)
+    const changeStream: ChangeStream = this.getCollection().watch<ShowStyle, ChangeStreamDocument<ShowStyle>>([], options)
     changeStream.on('change', () => this.onChange())
     this.logger.debug('Listening for ShowStyleConfiguration collection changes...')
   }

--- a/src/data-access/repositories/mongo/mongo-show-style-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-show-style-repository.ts
@@ -4,12 +4,18 @@ import { ShowStyle } from '../../../model/entities/show-style'
 import { MongoDatabase } from './mongo-database'
 import { NotFoundException } from '../../../model/exceptions/not-found-exception'
 import { MongoEntityConverter, MongoShowStyle } from './mongo-entity-converter'
+import { ShowStyleVariantRepository } from '../interfaces/show-style-variant-repository'
+import { ShowStyleVariant } from '../../../model/entities/show-style-variant'
 
 const COLLECTION_NAME: string = 'showStyleBases'
 
 export class MongoShowStyleRepository extends BaseMongoRepository implements ShowStyleRepository {
 
-  constructor(mongoDatabase: MongoDatabase, private readonly mongoEntityConverter: MongoEntityConverter) {
+  constructor(
+    mongoDatabase: MongoDatabase,
+    private readonly showStyleVariantRepository: ShowStyleVariantRepository,
+    private readonly mongoEntityConverter: MongoEntityConverter
+  ) {
     super(mongoDatabase)
   }
 
@@ -25,6 +31,8 @@ export class MongoShowStyleRepository extends BaseMongoRepository implements Sho
     if (!mongoShowStyle) {
       throw new NotFoundException(`No ShowStyle found for showStyleId: ${showStyleId}`)
     }
-    return this.mongoEntityConverter.convertShowStyle(mongoShowStyle)
+
+    const showStyleVariants: ShowStyleVariant[] = await this.showStyleVariantRepository.getShowStyleVariantsForShowStyle(showStyleId)
+    return this.mongoEntityConverter.convertShowStyle(mongoShowStyle, showStyleVariants)
   }
 }

--- a/src/data-access/repositories/mongo/mongo-show-style-variant-configuration-listener.ts
+++ b/src/data-access/repositories/mongo/mongo-show-style-variant-configuration-listener.ts
@@ -28,7 +28,7 @@ export class MongoShowStyleVariantConfigurationListener extends BaseMongoReposit
   }
 
   private onChange(): void {
-    // We just want to notify that a changed has been made
+    // We just want to notify that a change has been made
     this.onUpdatedCallback({} as ShowStyleVariant)
   }
 

--- a/src/data-access/repositories/mongo/mongo-show-style-variant-configuration-listener.ts
+++ b/src/data-access/repositories/mongo/mongo-show-style-variant-configuration-listener.ts
@@ -1,0 +1,52 @@
+import { BaseMongoRepository } from './base-mongo-repository'
+import { DataChangedListener } from '../interfaces/data-changed-listener'
+import { ShowStyleVariant } from '../../../model/entities/show-style-variant'
+import { Logger } from '../../../logger/logger'
+import { MongoDatabase } from './mongo-database'
+import { ChangeStream, ChangeStreamDocument, ChangeStreamOptions } from 'mongodb'
+import { UnsupportedOperationException } from '../../../model/exceptions/unsupported-operation-exception'
+
+const SHOW_STYLE_VARIANT_CONFIGURATION_COLLECTION_NAME: string = 'showStyleVariants'
+
+export class MongoShowStyleVariantConfigurationListener extends BaseMongoRepository implements DataChangedListener<ShowStyleVariant> {
+
+  private readonly logger: Logger
+
+  private onUpdatedCallback: (showStyleVariant: ShowStyleVariant) => void
+
+  constructor(mongoDatabase: MongoDatabase, logger: Logger) {
+    super(mongoDatabase)
+    this.logger = logger.tag(MongoShowStyleVariantConfigurationListener.name)
+    mongoDatabase.onConnect(SHOW_STYLE_VARIANT_CONFIGURATION_COLLECTION_NAME, () => this.listenForChanges())
+  }
+
+  private listenForChanges(): void {
+    const options: ChangeStreamOptions = { fullDocument: 'updateLookup' }
+    const changeStream: ChangeStream = this.getCollection().watch<ShowStyleVariant, ChangeStreamDocument<ShowStyleVariant>>([], options)
+    changeStream.on('change', () => this.onChange())
+    this.logger.debug('Listening for ShowStyleVariantConfiguration collection changes...')
+  }
+
+  private onChange(): void {
+    // We just want to notify that a changed has been made
+    this.onUpdatedCallback({} as ShowStyleVariant)
+  }
+
+  protected getCollectionName(): string {
+    return SHOW_STYLE_VARIANT_CONFIGURATION_COLLECTION_NAME
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public onCreated(_onCreatedCallback: (data: ShowStyleVariant) => void): void {
+    throw new UnsupportedOperationException(`${MongoShowStyleVariantConfigurationListener.prototype.onCreated.name} is not supported`)
+  }
+
+  public onUpdated(onUpdatedCallback: (data: ShowStyleVariant) => void): void {
+    this.onUpdatedCallback = onUpdatedCallback
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public onDeleted(_onDeletedCallback: (id: string) => void): void {
+    throw new UnsupportedOperationException(`${MongoShowStyleVariantConfigurationListener.prototype.onDeleted.name} is not supported`)
+  }
+}

--- a/src/data-access/repositories/mongo/mongo-show-style-variant-repository.ts
+++ b/src/data-access/repositories/mongo/mongo-show-style-variant-repository.ts
@@ -23,6 +23,11 @@ export class MongoShowStyleVariantRepository extends BaseMongoRepository impleme
     return COLLECTION_NAME
   }
 
+  public async getShowStyleVariantsForShowStyle(showStyleId: string): Promise<ShowStyleVariant[]> {
+    const mongoShowStyleVariants: MongoShowStyleVariant[] = await this.getCollection().find<MongoShowStyleVariant>({ showStyleBaseId: showStyleId }).toArray()
+    return this.mongoEntityConverter.convertShowStyleVariants(mongoShowStyleVariants)
+  }
+
   public async getShowStyleVariant(rundownId: string): Promise<ShowStyleVariant> {
     const rundown: Rundown = await this.rundownRepository.getRundown(rundownId)
     const mongoShowStyleVariant: MongoShowStyleVariant | null = await this.getCollection().findOne<MongoShowStyleVariant>({ _id: rundown.getShowStyleVariantId() })

--- a/src/model/entities/show-style.ts
+++ b/src/model/entities/show-style.ts
@@ -1,3 +1,6 @@
+import { ShowStyleVariant } from './show-style-variant'
+
 export interface ShowStyle {
   blueprintConfiguration: unknown
+  variants: ShowStyleVariant[]
 }

--- a/src/model/value-objects/blueprint.ts
+++ b/src/model/value-objects/blueprint.ts
@@ -12,6 +12,7 @@ export type Blueprint = BlueprintOnTimelineGenerate & BlueprintGetEndStateForPar
 export interface BlueprintOnTimelineGenerate {
   onTimelineGenerate(
     configuration: Configuration,
+    showStyleVariantId: string,
     timeline: Timeline,
     activePart: Part,
     previousRundownPersistentState: RundownPersistentState | undefined,
@@ -29,7 +30,7 @@ export interface BlueprintGetEndStateForPart {
 }
 
 export interface BlueprintGenerateActions {
-  generateActions(configuration: Configuration, actionManifests: ActionManifest[]): Action[]
+  generateActions(configuration: Configuration, showStyleVariantId: string, actionManifests: ActionManifest[]): Action[]
 
   /**
    * If any Action need to have data only accessible at the time of executing the action,


### PR DESCRIPTION
Our Blueprints did not take ShowStyleVariants into account. So whenever we would ask for the selected graphics setup, we would always get the default and never the one matching our ShowStyleVariant. Blueprints now take ShowStyleVariants into account when mapping Cores blueprintConfiugration into TV2s.

Added validation to ShowStyleVariants to check whether they have a GfxDefaults.