### PR TITLE
SOF-2011: Missing newlines in lower third graphics generated by actions

### DIFF
--- a/src/blueprints/tv2/helpers/tv2-action-manifest-mapper.ts
+++ b/src/blueprints/tv2/helpers/tv2-action-manifest-mapper.ts
@@ -21,7 +21,7 @@ import { Tv2AudioMode } from '../enums/tv2-audio-mode'
 const SPLIT_SCREEN_ACTION_MANIFEST_ID: string = 'select_dve'
 const VIDEO_CLIP_ACTION_MANIFEST_ID: string = 'select_server_clip'
 const FULLSCREEN_GRAPHICS_ACTION_MANIFEST_ID: string = 'select_full_grafik'
-const OVERLAY_GRAPHCIS_ACTION_MANIFEST_IDS: string[] = ['studio0_graphicsLower', 'studio0_graphicsIdent', 'studio0_overlay', 'studio0_pilotOverlay']
+const OVERLAY_GRAPHICS_ACTION_MANIFEST_IDS: string[] = ['studio0_graphicsLower', 'studio0_graphicsIdent', 'studio0_overlay', 'studio0_pilotOverlay']
 
 export class Tv2ActionManifestMapper {
 
@@ -111,7 +111,7 @@ export class Tv2ActionManifestMapper {
 
   public mapToOverlayGraphicsData(actionManifests: ActionManifest[]): Tv2OverlayGraphicsManifestData[] {
     return actionManifests
-      .filter((actionManifest): actionManifest is ActionManifest<Tv2ActionManifestOverlayGraphicsData> => OVERLAY_GRAPHCIS_ACTION_MANIFEST_IDS.includes(actionManifest.actionId))
+      .filter((actionManifest): actionManifest is ActionManifest<Tv2ActionManifestOverlayGraphicsData> => OVERLAY_GRAPHICS_ACTION_MANIFEST_IDS.includes(actionManifest.actionId))
       .map(actionManifest => {
         const data: Tv2ActionManifestOverlayGraphicsData = actionManifest.data
         return {

--- a/src/blueprints/tv2/timeline-object-factories/tv2-caspar-cg-timeline-object-factory.ts
+++ b/src/blueprints/tv2/timeline-object-factories/tv2-caspar-cg-timeline-object-factory.ts
@@ -30,6 +30,7 @@ import {
 } from '../timeline-state-resolver-types/tv2-caspar-cg-types'
 
 const HTML_GRAPHICS_INDEX_FILENAME: string = 'index'
+const ACTION_MANIFEST_DISPLAY_NAME_DATA_SEPARATOR: string = '\n - '
 
 export class Tv2CasparCgTimelineObjectFactory implements Tv2GraphicsElementTimelineObjectFactory, Tv2GraphicsSplitScreenTimelineObjectFactory, Tv2VideoClipTimelineObjectFactory {
 
@@ -143,7 +144,7 @@ export class Tv2CasparCgTimelineObjectFactory implements Tv2GraphicsElementTimel
             display: Tv2CasparCgTemplateDisplayMode.PROGRAM,
             payload: {
               type: overlayGraphicsData.templateName,
-              0: overlayGraphicsData.displayText
+              ...Object.fromEntries(overlayGraphicsData.displayText.split(ACTION_MANIFEST_DISPLAY_NAME_DATA_SEPARATOR).entries()), // TODO: When ingest is implemented, this should no longer be based on the display name.
             }
           }
         }

--- a/src/blueprints/tv2/timeline-object-factories/tv2-viz-timeline-object-factory.ts
+++ b/src/blueprints/tv2/timeline-object-factories/tv2-viz-timeline-object-factory.ts
@@ -24,6 +24,8 @@ enum EngineName {
   WALL = 'WALL1'
 }
 
+const ACTION_MANIFEST_DISPLAY_NAME_DATA_SEPARATOR: string = '\n - '
+
 export class Tv2VizTimelineObjectFactory implements Tv2GraphicsCommandTimelineObjectFactory, Tv2GraphicsElementTimelineObjectFactory {
 
   public createThemeOutTimelineObject(blueprintConfiguration: Tv2BlueprintConfiguration): VizMseElementInternalTimelineObject {
@@ -173,7 +175,7 @@ export class Tv2VizTimelineObjectFactory implements Tv2GraphicsCommandTimelineOb
       deviceType: DeviceType.VIZ_MSE,
       type: VizType.ELEMENT_INTERNAL,
       templateName: overlayGraphicsData.templateName,
-      templateData: [overlayGraphicsData.displayText],
+      templateData: overlayGraphicsData.displayText.split(ACTION_MANIFEST_DISPLAY_NAME_DATA_SEPARATOR), // TODO: When ingest is implemented, this should no longer be based on the display name.
       channelName: EngineName.OVERLAY,
       showName: blueprintConfiguration.showStyle.selectedGraphicsSetup.overlayShowName ?? ''
     }

--- a/src/blueprints/tv2/timeline-state-resolver-types/tv2-caspar-cg-types.ts
+++ b/src/blueprints/tv2/timeline-state-resolver-types/tv2-caspar-cg-types.ts
@@ -14,7 +14,7 @@ export interface Tv2CasparCgTemplateData {
       display: Tv2CasparCgTemplateDisplayMode
       payload: {
         type: string
-        0: string
+        [locatorIndex: number]: string
       }
     }
     [Tv2CasparCgTemplateSlotType.IDENT]?: {


### PR DESCRIPTION
The structured template data for graphics are located in the `content` property under the `expectedPlayoutItems` property on `AdlibPieces` coming from Sofie Core. This property is currently not mapped to `ActionManifests` and since the display name for the adlib pieces contain the necessary information, this is still kept as the base for extracting the template data.
This should be reworked when the ingest flow is rewritten for Sofie server.

This has only been tested against the test tools in Sofie Core to see that the single lines of the template data are split correctly up into multiple lines.