### PR TITLE
SOF-2016: Expose invalidity for parts

### DIFF
--- a/src/business-logic/services/ingested-entity-to-entity-mapper.ts
+++ b/src/business-logic/services/ingested-entity-to-entity-mapper.ts
@@ -97,6 +97,7 @@ export class IngestedEntityToEntityMapper {
       isUntimed: ingestedPart.isUntimed,
       pieces: ingestedPart.ingestedPieces.map((ingestedPiece: IngestedPiece) => this.convertIngestedPieceToPiece(ingestedPiece)),
       expectedDuration: ingestedPart.expectedDuration,
+      invalidity: ingestedPart.invalidity,
       inTransition: ingestedPart.inTransition,
       outTransition: ingestedPart.outTransition,
       autoNext: ingestedPart.autoNext,
@@ -125,6 +126,7 @@ export class IngestedEntityToEntityMapper {
       pieces: updatedPieces,
       executedAt: partToBeUpdated.getExecutedAt(),
       playedDuration: partToBeUpdated.getPlayedDuration(),
+      invalidity: partToBeUpdated.invalidity,
       endState: partToBeUpdated.getEndState(),
       timings: this.getPartTimings(partToBeUpdated),
       ingestedPart

--- a/src/business-logic/services/ingested-entity-to-entity-mapper.ts
+++ b/src/business-logic/services/ingested-entity-to-entity-mapper.ts
@@ -126,7 +126,6 @@ export class IngestedEntityToEntityMapper {
       pieces: updatedPieces,
       executedAt: partToBeUpdated.getExecutedAt(),
       playedDuration: partToBeUpdated.getPlayedDuration(),
-      invalidity: partToBeUpdated.invalidity,
       endState: partToBeUpdated.getEndState(),
       timings: this.getPartTimings(partToBeUpdated),
       ingestedPart

--- a/src/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/src/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -30,6 +30,7 @@ import { SystemInformation } from '../../../model/entities/system-information'
 import { Device } from '../../../model/entities/device'
 import { StatusCode } from '../../../model/enums/status-code'
 import { RundownMode } from '../../../model/enums/rundown-mode'
+import { Invalidity } from '../../../model/value-objects/invalidity'
 
 export interface MongoId {
   _id: string
@@ -89,6 +90,7 @@ export interface MongoPart extends MongoId {
   expectedDuration?: number
   executedAt?: number
   playedDuration?: number
+  invalidity?: Invalidity
 
   inTransition: InTransition
   outTransition: OutTransition
@@ -336,6 +338,7 @@ export class MongoEntityConverter {
       expectedDuration: part.expectedDuration,
       executedAt: part.getExecutedAt(),
       playedDuration: part.getPlayedDuration(),
+      invalidity: part.invalidity,
 
       inTransition: part.getInTransition(),
       outTransition: part.outTransition,

--- a/src/data-access/repositories/mongo/mongo-ingested-entity-converter.ts
+++ b/src/data-access/repositories/mongo/mongo-ingested-entity-converter.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../model/value-objects/rundown-timing'
 import { RundownTimingType } from '../../../model/enums/rundown-timing-type'
 import { MongoId } from './mongo-entity-converter'
+import { Invalidity } from '../../../model/value-objects/invalidity'
 
 export interface MongoIngestedRundown extends MongoId {
   name: string
@@ -82,6 +83,7 @@ export interface MongoIngestedPart extends MongoId {
   autoNextOverlap: number
   disableNextInTransition: boolean
   timings?: PartTimings
+  invalidity?: Invalidity
 }
 
 export interface MongoIngestedPiece extends MongoId {
@@ -196,6 +198,7 @@ export class MongoIngestedEntityConverter {
       disableNextInTransition: mongoPart.disableNextInTransition,
       isUntimed: mongoPart.untimed ?? false,
       timings: mongoPart.timings,
+      invalidity: mongoPart.invalidity
     }
   }
 

--- a/src/model/entities/ingested-part.ts
+++ b/src/model/entities/ingested-part.ts
@@ -3,6 +3,7 @@ import { OutTransition } from '../value-objects/out-transition'
 import { AutoNext } from '../value-objects/auto-next'
 import { PartTimings } from '../value-objects/part-timings'
 import { IngestedPiece } from './ingested-piece'
+import { Invalidity } from '../value-objects/invalidity'
 
 export interface IngestedPart {
   readonly id: string
@@ -11,6 +12,7 @@ export interface IngestedPart {
   readonly name: string
   readonly rank: number
   readonly expectedDuration?: number
+  readonly invalidity?: Invalidity
 
   readonly inTransition: InTransition
   readonly outTransition: OutTransition

--- a/src/model/entities/part.ts
+++ b/src/model/entities/part.ts
@@ -9,6 +9,7 @@ import { PartEndState } from '../value-objects/part-end-state'
 import { IngestedPart } from './ingested-part'
 import { IngestedPiece } from './ingested-piece'
 import { UNSYNCED_ID_POSTFIX } from '../value-objects/unsynced_constants'
+import { Invalidity } from '../value-objects/invalidity'
 
 export interface PartInterface {
   id: string
@@ -24,6 +25,7 @@ export interface PartInterface {
   expectedDuration?: number
   executedAt?: number
   playedDuration?: number
+  invalidity?: Invalidity
 
   inTransition: InTransition
   outTransition: OutTransition
@@ -55,6 +57,7 @@ export class Part {
 
   public readonly autoNext?: AutoNext
   public readonly disableNextInTransition: boolean
+  public readonly invalidity?: Invalidity
 
   private segmentId: string
   private rank: number
@@ -96,6 +99,7 @@ export class Part {
     this.isPartOnAir = part.isOnAir
     this.isPartNext = part.isNext
     this.expectedDuration = part.expectedDuration
+    this.invalidity = part.invalidity
 
     this.inTransition = part.inTransition ?? { keepPreviousPartAliveDuration: 0, delayPiecesDuration: 0 }
     this.outTransition = part.outTransition ?? { keepAliveDuration: 0 }

--- a/src/presentation/dtos/part-dto.ts
+++ b/src/presentation/dtos/part-dto.ts
@@ -1,6 +1,7 @@
 import { Part, PartMetadata } from '../../model/entities/part'
 import { PieceDto } from './piece-dto'
 import { AutoNext } from '../../model/value-objects/auto-next'
+import { Invalidity } from '../../model/value-objects/invalidity'
 
 export class PartDto {
   public readonly id: string
@@ -14,6 +15,7 @@ export class PartDto {
   public readonly expectedDuration?: number
   public readonly executedAt: number
   public readonly playedDuration: number
+  public readonly invalidity?: Invalidity
   public readonly autoNext?: AutoNext
   public readonly isPlanned: boolean
   public readonly metadata?: PartMetadata
@@ -31,6 +33,7 @@ export class PartDto {
     this.expectedDuration = part.expectedDuration
     this.executedAt = part.getExecutedAt()
     this.playedDuration = part.getPlayedDuration()
+    this.invalidity = part.invalidity
     this.autoNext = part.autoNext
     this.isPlanned = part.isPlanned
     this.metadata = part.metadata


### PR DESCRIPTION
Depends on: https://github.com/tv2/sofie-blueprints-inews/pull/245.

Adds the invalidity attribute to parts (in various forms) and exposes it to the REST endpoints via the `PartDto`.

Update: The logic for ensuring that we can't take an invalid part will be made in a separate PR.