### PR TITLE
SOF-2013 - Reingest data upon show style variant change

### DIFF
--- a/src/business-logic/facades/service-facade.ts
+++ b/src/business-logic/facades/service-facade.ts
@@ -40,6 +40,7 @@ export class ServiceFacade {
       RepositoryFacade.createPieceRepository(),
       RepositoryFacade.createTimelineRepository(),
       ServiceFacade.createTimelineBuilder(),
+      ServiceFacade.createIngestService(),
       TimeoutCallbackScheduler.getInstance(LoggerFacade.createLogger()),
       BlueprintsFacade.createBlueprint()
     )

--- a/src/business-logic/services/ingested-entity-to-entity-mapper.ts
+++ b/src/business-logic/services/ingested-entity-to-entity-mapper.ts
@@ -60,7 +60,7 @@ export class IngestedEntityToEntityMapper {
       isNext: false,
       isUnsynced: false,
       expectedDurationInMs: ingestedSegment.budgetDuration,
-      definesShowStyleVariant: ingestedSegment.definesShowStyleVariant,
+      definesShowStyleVariant: ingestedSegment.definesShowStyleVariant ?? false,
       parts: [],
     })
   }

--- a/src/business-logic/services/ingested-entity-to-entity-mapper.ts
+++ b/src/business-logic/services/ingested-entity-to-entity-mapper.ts
@@ -60,6 +60,7 @@ export class IngestedEntityToEntityMapper {
       isNext: false,
       isUnsynced: false,
       expectedDurationInMs: ingestedSegment.budgetDuration,
+      definesShowStyleVariant: ingestedSegment.definesShowStyleVariant,
       parts: [],
     })
   }

--- a/src/business-logic/services/rundown-timeline-service.ts
+++ b/src/business-logic/services/rundown-timeline-service.ts
@@ -156,14 +156,13 @@ export class RundownTimelineService implements RundownService {
     this.rundownEventEmitter.emitSetNextEvent(rundown)
     this.startAutoNext(timeline, rundownId)
 
+    await this.deleteUnsyncedPreviousPart(rundown)
+    await this.deleteUnsyncedSegments(rundown)
+    await this.saveRundown(rundown)
 
     if (rundown.getActiveSegment().definesShowStyleVariant) {
       await this.ingestService.reloadIngestData(rundown.id)
     }
-
-    await this.deleteUnsyncedPreviousPart(rundown)
-    await this.deleteUnsyncedSegments(rundown)
-    await this.saveRundown(rundown)
   }
 
   private async deleteUnsyncedPreviousPart(rundown: Rundown): Promise<void> {

--- a/src/business-logic/services/rundown-timeline-service.ts
+++ b/src/business-logic/services/rundown-timeline-service.ts
@@ -21,6 +21,7 @@ import { AlreadyActivatedException } from '../../model/exceptions/already-activa
 import { IngestedRundownRepository } from '../../data-access/repositories/interfaces/ingested-rundown-repository'
 import { RundownMode } from '../../model/enums/rundown-mode'
 import { AlreadyRehearsalException } from '../../model/exceptions/already-rehearsal-exception'
+import { IngestService } from './interfaces/ingest-service'
 
 export class RundownTimelineService implements RundownService {
   constructor(
@@ -32,6 +33,7 @@ export class RundownTimelineService implements RundownService {
     private readonly pieceRepository: PieceRepository,
     private readonly timelineRepository: TimelineRepository,
     private readonly timelineBuilder: TimelineBuilder,
+    private readonly ingestService: IngestService,
     private readonly callbackScheduler: CallbackScheduler,
     private readonly blueprint: Blueprint
   ) {}
@@ -153,6 +155,11 @@ export class RundownTimelineService implements RundownService {
     this.rundownEventEmitter.emitTakeEvent(rundown)
     this.rundownEventEmitter.emitSetNextEvent(rundown)
     this.startAutoNext(timeline, rundownId)
+
+
+    if (rundown.getActiveSegment().definesShowStyleVariant) {
+      await this.ingestService.reloadIngestData(rundown.id)
+    }
 
     await this.deleteUnsyncedPreviousPart(rundown)
     await this.deleteUnsyncedSegments(rundown)

--- a/src/business-logic/services/test/rundown-timeline-service.spec.ts
+++ b/src/business-logic/services/test/rundown-timeline-service.spec.ts
@@ -23,7 +23,7 @@ import { Timeline } from '../../../model/entities/timeline'
 import { TimelineObject, TimelineObjectGroup } from '../../../model/entities/timeline-object'
 import { RundownMode } from '../../../model/enums/rundown-mode'
 import { AlreadyRehearsalException } from '../../../model/exceptions/already-rehearsal-exception'
-import {IngestService} from '../interfaces/ingest-service'
+import { IngestService } from '../interfaces/ingest-service'
 
 describe(RundownTimelineService.name, () => {
   describe(`${RundownTimelineService.prototype.deleteRundown.name}`, () => {

--- a/src/business-logic/services/test/rundown-timeline-service.spec.ts
+++ b/src/business-logic/services/test/rundown-timeline-service.spec.ts
@@ -23,6 +23,7 @@ import { Timeline } from '../../../model/entities/timeline'
 import { TimelineObject, TimelineObjectGroup } from '../../../model/entities/timeline-object'
 import { RundownMode } from '../../../model/enums/rundown-mode'
 import { AlreadyRehearsalException } from '../../../model/exceptions/already-rehearsal-exception'
+import {IngestService} from '../interfaces/ingest-service'
 
 describe(RundownTimelineService.name, () => {
   describe(`${RundownTimelineService.prototype.deleteRundown.name}`, () => {
@@ -368,6 +369,7 @@ function createTestee(params?: {
   pieceRepository?: PieceRepository
   timelineRepository?: TimelineRepository
   timelineBuilder?: TimelineBuilder
+  ingestService?: IngestService
   callbackScheduler?: CallbackScheduler
   blueprint?: Blueprint
 }): RundownTimelineService {
@@ -380,6 +382,7 @@ function createTestee(params?: {
     params?.pieceRepository ?? instance(mock<PieceRepository>()),
     params?.timelineRepository ?? instance(mock<TimelineRepository>()),
     params?.timelineBuilder ?? instance(mock<TimelineBuilder>()),
+    params?.ingestService ?? instance(mock<IngestService>()),
     params?.callbackScheduler ?? instance(mock<CallbackScheduler>()),
     params?.blueprint ?? instance(mock<Blueprint>())
   )

--- a/src/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/src/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -73,6 +73,7 @@ export interface MongoSegment extends MongoId {
   invalidity?: {
     reason: string
   }
+  definesShowStyleVariant: boolean
 }
 
 export interface MongoPart extends MongoId {
@@ -304,7 +305,8 @@ export class MongoEntityConverter {
       isUnsynced: segment.isUnsynced(),
       budgetDuration: segment.expectedDurationInMs,
       executedAtEpochTime: segment.getExecutedAtEpochTime(),
-      invalidity: segment.invalidity
+      invalidity: segment.invalidity,
+      definesShowStyleVariant: segment.definesShowStyleVariant
     }
   }
 

--- a/src/data-access/repositories/mongo/mongo-ingested-entity-converter.ts
+++ b/src/data-access/repositories/mongo/mongo-ingested-entity-converter.ts
@@ -58,7 +58,7 @@ export interface MongoIngestedSegment extends MongoId {
   metaData?: unknown // This is the current spelling in the database from Core... TOD: Update when we control Ingest
   budgetDuration?: number
   invalidity?: { reason: string }
-  definesShowStyleVariant?: boolean
+  definesShowStyleVariant: boolean
 }
 
 export interface MongoIngestedPart extends MongoId {

--- a/src/data-access/repositories/mongo/mongo-ingested-entity-converter.ts
+++ b/src/data-access/repositories/mongo/mongo-ingested-entity-converter.ts
@@ -58,6 +58,7 @@ export interface MongoIngestedSegment extends MongoId {
   metaData?: unknown // This is the current spelling in the database from Core... TOD: Update when we control Ingest
   budgetDuration?: number
   invalidity?: { reason: string }
+  definesShowStyleVariant?: boolean
 }
 
 export interface MongoIngestedPart extends MongoId {
@@ -167,7 +168,8 @@ export class MongoIngestedEntityConverter {
       metadata: mongoSegment.metaData,
       ingestedParts: [],
       budgetDuration: mongoSegment.budgetDuration ?? undefined,
-      invalidity: mongoSegment.invalidity
+      invalidity: mongoSegment.invalidity,
+      definesShowStyleVariant: mongoSegment.definesShowStyleVariant
     }
   }
 

--- a/src/model/entities/ingested-segment.ts
+++ b/src/model/entities/ingested-segment.ts
@@ -12,4 +12,5 @@ export interface IngestedSegment {
   readonly budgetDuration?: number
   readonly ingestedParts: Readonly<IngestedPart[]>
   readonly invalidity?: Invalidity
+  readonly definesShowStyleVariant?: boolean
 }

--- a/src/model/entities/ingested-segment.ts
+++ b/src/model/entities/ingested-segment.ts
@@ -12,5 +12,5 @@ export interface IngestedSegment {
   readonly budgetDuration?: number
   readonly ingestedParts: Readonly<IngestedPart[]>
   readonly invalidity?: Invalidity
-  readonly definesShowStyleVariant?: boolean
+  readonly definesShowStyleVariant: boolean
 }

--- a/src/model/entities/segment.ts
+++ b/src/model/entities/segment.ts
@@ -23,7 +23,7 @@ export interface SegmentInterface {
   executedAtEpochTime?: number
   expectedDurationInMs?: number
   invalidity?: Invalidity
-  definesShowStyleVariant?: boolean
+  definesShowStyleVariant: boolean
 }
 
 export class Segment {
@@ -35,7 +35,7 @@ export class Segment {
   public readonly referenceTag?: string
   public readonly metadata?: unknown
   public readonly invalidity?: Invalidity
-  public readonly definesShowStyleVariant?: boolean
+  public readonly definesShowStyleVariant: boolean
   public rank: number
 
   private isSegmentOnAir: boolean

--- a/src/model/entities/segment.ts
+++ b/src/model/entities/segment.ts
@@ -23,6 +23,7 @@ export interface SegmentInterface {
   executedAtEpochTime?: number
   expectedDurationInMs?: number
   invalidity?: Invalidity
+  definesShowStyleVariant?: boolean
 }
 
 export class Segment {
@@ -34,6 +35,7 @@ export class Segment {
   public readonly referenceTag?: string
   public readonly metadata?: unknown
   public readonly invalidity?: Invalidity
+  public readonly definesShowStyleVariant?: boolean
   public rank: number
 
   private isSegmentOnAir: boolean
@@ -57,6 +59,7 @@ export class Segment {
     this.expectedDurationInMs = segment.expectedDurationInMs
     this.executedAtEpochTime = segment.executedAtEpochTime
     this.invalidity = segment.invalidity
+    this.definesShowStyleVariant = segment.definesShowStyleVariant
     this.setParts(segment.parts ?? [])
   }
 


### PR DESCRIPTION
This PR depends on: https://github.com/tv2/sofie-blueprints-inews/pull/246

Whenever a segment has the new property ```definesShowStyleVariant```set to true, we reingest the rundown data to ensure that all pieces have changes timeline objects that fit the new show style. 