### PR TITLE
Sof 2029 gracefully continue when lookahead config set to non existent value

### DIFF
--- a/src/data-access/facades/repository-facade.ts
+++ b/src/data-access/facades/repository-facade.ts
@@ -84,7 +84,7 @@ export class RepositoryFacade {
   public static createRundownRepository(): RundownRepository {
     const mongoRundownRepository: RundownRepository = new MongoRundownRepository(
       MongoDatabase.getInstance(LoggerFacade.createLogger()),
-      new MongoEntityConverter(),
+      new MongoEntityConverter(LoggerFacade.createLogger()),
       RepositoryFacade.createSegmentRepository(),
       RepositoryFacade.createPieceRepository()
     )
@@ -115,7 +115,7 @@ export class RepositoryFacade {
   public static createSegmentRepository(): SegmentRepository {
     const mongoSegmentRepository: SegmentRepository = new MongoSegmentRepository(
       MongoDatabase.getInstance(LoggerFacade.createLogger()),
-      new MongoEntityConverter(),
+      new MongoEntityConverter(LoggerFacade.createLogger()),
       RepositoryFacade.createPartRepository()
     )
     return CachedSegmentRepository.getInstance(mongoSegmentRepository)
@@ -140,7 +140,7 @@ export class RepositoryFacade {
   public static createPartRepository(): PartRepository {
     const mongoPartRepository: PartRepository = new MongoPartRepository(
       MongoDatabase.getInstance(LoggerFacade.createLogger()),
-      new MongoEntityConverter(),
+      new MongoEntityConverter(LoggerFacade.createLogger()),
       RepositoryFacade.createPieceRepository()
     )
     return CachedPartRepository.getInstance(mongoPartRepository)
@@ -171,7 +171,7 @@ export class RepositoryFacade {
   }
 
   public static createPieceRepository(): PieceRepository {
-    return new MongoPieceRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter())
+    return new MongoPieceRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter(LoggerFacade.createLogger()))
   }
 
   public static createIngestedPieceRepository(): IngestedPieceRepository {
@@ -179,7 +179,7 @@ export class RepositoryFacade {
   }
 
   public static createTimelineRepository(): TimelineRepository {
-    return new MongoTimelineRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter())
+    return new MongoTimelineRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter(LoggerFacade.createLogger()))
   }
 
   public static createConfigurationRepository(): ConfigurationRepository {
@@ -191,14 +191,14 @@ export class RepositoryFacade {
   }
 
   private static createStudioRepository(): StudioRepository {
-    return new MongoStudioRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter())
+    return new MongoStudioRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter(LoggerFacade.createLogger()))
   }
 
   private static createShowStyleRepository(): ShowStyleRepository {
     return new MongoShowStyleRepository(
       MongoDatabase.getInstance(LoggerFacade.createLogger()),
       RepositoryFacade.createShowStyleVariantRepository(),
-      new MongoEntityConverter()
+      new MongoEntityConverter(LoggerFacade.createLogger())
     )
   }
 
@@ -225,7 +225,7 @@ export class RepositoryFacade {
   public static createShowStyleVariantRepository(): ShowStyleVariantRepository {
     return new MongoShowStyleVariantRepository(
       MongoDatabase.getInstance(LoggerFacade.createLogger()),
-      new MongoEntityConverter(),
+      new MongoEntityConverter(LoggerFacade.createLogger()),
       this.createRundownRepository()
     )
   }
@@ -243,23 +243,23 @@ export class RepositoryFacade {
   }
 
   public static createMediaRepository(): MediaRepository {
-    return new MongoMediaRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter())
+    return new MongoMediaRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter(LoggerFacade.createLogger()))
   }
 
   public static createSystemInformationRepository(): SystemInformationRepository {
-    return new MongoSystemInformationRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter())
+    return new MongoSystemInformationRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter(LoggerFacade.createLogger()))
   }
 
   public static createDeviceDataChangedListener(): DataChangedListener<Device> {
     return new MongoDeviceChangedListener(
       MongoDatabase.getInstance(LoggerFacade.createLogger()),
-      new MongoEntityConverter(),
+      new MongoEntityConverter(LoggerFacade.createLogger()),
       LoggerFacade.createLogger()
     )
   }
 
   public static createDeviceRepository(): DeviceRepository {
-    return new MongoDeviceRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter())
+    return new MongoDeviceRepository(MongoDatabase.getInstance(LoggerFacade.createLogger()), new MongoEntityConverter(LoggerFacade.createLogger()))
   }
 
   public static createStatusMessageRepository(): StatusMessageRepository {

--- a/src/data-access/repositories/mongo/mongo-entity-converter.ts
+++ b/src/data-access/repositories/mongo/mongo-entity-converter.ts
@@ -25,12 +25,13 @@ import { ShowStyleVariant } from '../../../model/entities/show-style-variant'
 import { Media } from '../../../model/entities/media'
 import { RundownTiming } from '../../../model/value-objects/rundown-timing'
 import { IngestedPart } from '../../../model/entities/ingested-part'
-import { UnsupportedOperationException } from '../../../model/exceptions/unsupported-operation-exception'
 import { SystemInformation } from '../../../model/entities/system-information'
 import { Device } from '../../../model/entities/device'
 import { StatusCode } from '../../../model/enums/status-code'
 import { RundownMode } from '../../../model/enums/rundown-mode'
 import { Invalidity } from '../../../model/value-objects/invalidity'
+import { Logger } from '../../../logger/logger'
+
 
 export interface MongoId {
   _id: string
@@ -187,6 +188,11 @@ export interface MongoDevice extends MongoId {
 const MILLISECONDS_TO_SECONDS_RATIO: number = 1000
 
 export class MongoEntityConverter {
+  private readonly logger: Logger
+
+  constructor(logger: Logger) {
+    this.logger = logger.tag(MongoEntityConverter.name)
+  }
 
   public convertToRundown(mongoRundown: MongoRundown, segments: Segment[], infinitePieces?: Piece[]): Rundown {
     const alreadyActiveProperties: RundownAlreadyActiveProperties | undefined = [RundownMode.ACTIVE, RundownMode.REHEARSAL].includes(mongoRundown.mode)
@@ -447,7 +453,8 @@ export class MongoEntityConverter {
         return LookaheadMode.WHEN_CLEAR
       }
       default: {
-        throw new UnsupportedOperationException(`Found unknown number for LookAhead: ${lookAheadNumber}`)
+        this.logger.warn(`Found unknown number for LookAhead: ${lookAheadNumber}. Defaulting to NONE.`)
+        return LookaheadMode.NONE
       }
     }
   }


### PR DESCRIPTION
Refactored from throwing an exception which brought down the entire server to logging a warning and setting a default value. Avoiding bulky and noisy exception handling (which often has unintended side-effects) wherever possible.